### PR TITLE
fix: allow :port format in Docker backend_addr validation

### DIFF
--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -73,13 +73,8 @@ func validateBackendAddress(addr string) error {
 	}
 
 	// For network addresses, validate host:port format
-	host, portStr, err := net.SplitHostPort(addr)
+	_, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
-		return errors.NewValidationError("invalid backend address format")
-	}
-
-	// Validate host is not empty
-	if host == "" {
 		return errors.NewValidationError("invalid backend address format")
 	}
 

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -450,11 +450,14 @@ func TestValidateBackendAddress(t *testing.T) {
 		{"valid unix socket", "unix:///var/run/app.sock", true, ""},
 		{"valid unix socket with complex path", "unix:///tmp/sockets/app.sock", true, ""},
 
+		// Valid addresses - port only (binds to all interfaces)
+		{"port only", ":8080", true, ""},
+		{"port only high", ":65535", true, ""},
+
 		// Invalid addresses - format issues
 		{"missing port", "localhost", false, "invalid backend address format"},
 		{"empty address", "", false, "backend address cannot be empty"},
-		{"just colon", ":", false, "invalid backend address format"},
-		{"missing host", ":8080", false, "invalid backend address format"},
+		{"just colon", ":", false, "invalid port"},
 		{"invalid unix prefix", "unix:/var/run/app.sock", false, "unix socket path must start with unix://"},
 		{"unix with port", "unix://socket:8080", false, "unix socket cannot have port"},
 


### PR DESCRIPTION
The Docker provider's validateBackendAddress function was incorrectly rejecting backend addresses in the ":port" format (e.g., ":8080"), even though this format is documented and commonly used in Docker containers to bind to all interfaces.

This fix removes the host validation check, allowing addresses with empty hosts to be accepted. The general backend address parser already supports this format, so this brings the Docker validation in line with the rest of the codebase.

Updated tests to reflect that ":port" format is now valid.