### PR TITLE
refactor: replace Docker polling with event-based monitoring

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -298,6 +298,10 @@ func (p *Provider) handleContainerEvent(ctx context.Context, configCh chan<- *co
 
 		select {
 		case configCh <- newConfig:
+			// Update lastConfig after successfully sending the new config
+			p.mu.Lock()
+			p.lastConfig = newConfig
+			p.mu.Unlock()
 		case <-ctx.Done():
 			return true
 		}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -12,11 +12,20 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/jtdowney/tsbridge/internal/config"
 	"github.com/jtdowney/tsbridge/internal/errors"
 )
+
+// DockerClient defines the methods required from a Docker client to be used by the provider
+type DockerClient interface {
+	ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error)
+	Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error)
+	Ping(ctx context.Context) (types.Ping, error)
+	Close() error
+}
 
 const (
 	// DefaultLabelPrefix is the default label prefix for tsbridge configuration
@@ -24,14 +33,11 @@ const (
 
 	// DefaultDockerEndpoint is the default Docker socket endpoint
 	DefaultDockerEndpoint = "unix:///var/run/docker.sock"
-
-	// watchInterval is the interval for polling Docker for changes
-	watchInterval = 5 * time.Second
 )
 
 // Provider implements config.Provider for Docker label-based configuration
 type Provider struct {
-	client      *client.Client
+	client      DockerClient
 	labelPrefix string
 	socketPath  string
 	mu          sync.RWMutex
@@ -165,50 +171,139 @@ func (p *Provider) Load(ctx context.Context) (*config.Config, error) {
 		cfg.Services = append(cfg.Services, *svc)
 	}
 
-	// Apply standard configuration processing
-	if err := config.ProcessLoadedConfigWithProvider(cfg, "docker"); err != nil {
-		return nil, err
+	// Apply standard configuration processing but skip full validation if no services
+	// For Docker provider, services can be added dynamically via container events
+	if len(cfg.Services) == 0 {
+		// Just validate OAuth credentials and apply defaults
+		if err := config.ProcessLoadedConfigWithProvider(cfg, "docker"); err != nil {
+			// If error is about missing services, ignore it for Docker provider
+			if !strings.Contains(err.Error(), "at least one service must be defined") {
+				return nil, err
+			}
+		}
+	} else {
+		// Full validation when services exist
+		if err := config.ProcessLoadedConfigWithProvider(cfg, "docker"); err != nil {
+			return nil, err
+		}
 	}
 
 	p.lastConfig = cfg
 	return cfg, nil
 }
 
-// Watch monitors Docker for configuration changes
+// Watch monitors Docker events for container configuration changes
 func (p *Provider) Watch(ctx context.Context) (<-chan *config.Config, error) {
 	configCh := make(chan *config.Config)
+	eventOptions := p.createEventOptions()
 
 	go func() {
 		defer close(configCh)
-
-		ticker := time.NewTicker(watchInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				newConfig, err := p.Load(ctx)
-				if err != nil {
-					slog.Error("failed to reload configuration from Docker", "error", err)
-					continue
-				}
-
-				// Check if configuration has changed
-				if !p.configEqual(p.getLastConfig(), newConfig) {
-					slog.Info("Docker configuration changed, reloading")
-					select {
-					case configCh <- newConfig:
-					case <-ctx.Done():
-						return
-					}
-				}
-			}
-		}
+		p.watchLoop(ctx, configCh, eventOptions)
 	}()
 
 	return configCh, nil
+}
+
+// createEventOptions creates the event filter options for Docker events
+func (p *Provider) createEventOptions() events.ListOptions {
+	eventFilters := filters.NewArgs()
+	eventFilters.Add("type", "container")
+	eventFilters.Add("event", "start")
+	eventFilters.Add("event", "stop")
+	eventFilters.Add("event", "die")
+	eventFilters.Add("event", "pause")
+	eventFilters.Add("event", "unpause")
+	eventFilters.Add("label", p.labelPrefix+".enabled=true")
+
+	return events.ListOptions{
+		Filters: eventFilters,
+	}
+}
+
+// watchLoop runs the main event watching loop with reconnection
+func (p *Provider) watchLoop(ctx context.Context, configCh chan<- *config.Config, eventOptions events.ListOptions) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			if p.processEventStream(ctx, configCh, eventOptions) {
+				return // Context cancelled
+			}
+
+			// Event stream closed, wait before reconnecting
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+				slog.Debug("Reconnecting to Docker events stream")
+			}
+		}
+	}
+}
+
+// processEventStream processes a single event stream connection
+func (p *Provider) processEventStream(ctx context.Context, configCh chan<- *config.Config, eventOptions events.ListOptions) bool {
+	events, errs := p.client.Events(ctx, eventOptions)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return true
+		case err := <-errs:
+			if err != nil {
+				slog.Error("Docker events stream error", "error", err)
+				return false // Return to restart event stream
+			}
+		case event := <-events:
+			if p.handleContainerEvent(ctx, configCh, event) {
+				return true // Context cancelled
+			}
+		}
+	}
+}
+
+// handleContainerEvent processes a single container event
+func (p *Provider) handleContainerEvent(ctx context.Context, configCh chan<- *config.Config, event events.Message) bool {
+	if event.Type != "container" {
+		return false
+	}
+
+	containerID := event.Actor.ID
+	if len(containerID) > 12 {
+		containerID = containerID[:12]
+	}
+
+	slog.Debug("Docker container event received",
+		"action", event.Action,
+		"container_name", event.Actor.Attributes["name"],
+		"container_id", containerID)
+
+	// Save the old config before loading new one
+	oldConfig := p.getLastConfig()
+
+	// Load new configuration when container event occurs
+	newConfig, err := p.Load(ctx)
+	if err != nil {
+		slog.Error("failed to reload configuration after Docker event", "error", err)
+		return false
+	}
+
+	// Check if configuration has changed
+	if !p.configEqual(oldConfig, newConfig) {
+		slog.Info("Docker configuration changed due to container event",
+			"action", event.Action,
+			"container_name", event.Actor.Attributes["name"])
+
+		select {
+		case configCh <- newConfig:
+		case <-ctx.Done():
+			return true
+		}
+	}
+
+	return false
 }
 
 // Name returns the provider name

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -1,6 +1,8 @@
 package docker
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -8,6 +10,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
 	"github.com/jtdowney/tsbridge/internal/config"
 	"github.com/jtdowney/tsbridge/internal/errors"
 	"github.com/stretchr/testify/assert"
@@ -663,6 +667,59 @@ func TestValidateDockerAccess_ErrorMessages(t *testing.T) {
 	}
 }
 
+func TestDockerProvider_WatchWithEvents(t *testing.T) {
+	// This test verifies that the Watch method uses Docker events instead of polling
+
+	t.Run("watch method signature", func(t *testing.T) {
+		// Test that the Watch method signature hasn't changed
+		provider := &Provider{
+			labelPrefix: "tsbridge",
+		}
+
+		// Test signature without calling - this verifies method exists
+		watchMethod := provider.Watch
+		assert.NotNil(t, watchMethod)
+	})
+
+	t.Run("createEventOptions configuration", func(t *testing.T) {
+		// Test the event options creation without requiring Docker client
+		provider := &Provider{
+			labelPrefix: "tsbridge",
+		}
+
+		options := provider.createEventOptions()
+		assert.NotNil(t, options.Filters)
+
+		// Verify event filters are properly configured
+		filters := options.Filters.Get("type")
+		assert.Contains(t, filters, "container")
+
+		events := options.Filters.Get("event")
+		assert.Contains(t, events, "start")
+		assert.Contains(t, events, "stop")
+		assert.Contains(t, events, "die")
+		assert.Contains(t, events, "pause")
+		assert.Contains(t, events, "unpause")
+
+		labels := options.Filters.Get("label")
+		assert.Contains(t, labels, "tsbridge.enabled=true")
+	})
+
+	t.Run("watch event filtering configuration", func(t *testing.T) {
+		// Verify that the Watch method would use proper event filters
+		// This is a unit test that doesn't require actual Docker connection
+		provider := &Provider{
+			labelPrefix: "tsbridge",
+		}
+
+		// Test that the provider has the correct label prefix
+		assert.Equal(t, "tsbridge", provider.labelPrefix)
+
+		// The actual event filtering is tested in integration tests
+		// where we can verify the filters are applied correctly
+	})
+}
+
 // mockFileInfo implements os.FileInfo for testing
 type mockFileInfo struct {
 	mode os.FileMode
@@ -674,3 +731,738 @@ func (m *mockFileInfo) Mode() os.FileMode  { return m.mode }
 func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (m *mockFileInfo) IsDir() bool        { return false }
 func (m *mockFileInfo) Sys() interface{}   { return nil }
+
+// mockDockerClient is a mock implementation of DockerClient for testing
+type mockDockerClient struct {
+	containers       []types.Container
+	eventsChan       chan events.Message
+	errsChan         chan error
+	listError        error
+	eventsError      error
+	pingError        error
+	closeError       error
+	eventsSent       []events.Message
+	mu               sync.Mutex
+	eventsStarted    bool
+	eventsCloseCount int
+}
+
+func newMockDockerClient() *mockDockerClient {
+	return &mockDockerClient{
+		eventsChan: make(chan events.Message, 10),
+		errsChan:   make(chan error, 10),
+	}
+}
+
+func (m *mockDockerClient) ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+	if m.listError != nil {
+		return nil, m.listError
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Apply filters if any
+	var result []types.Container
+
+	// Get filters
+	labelFilters := options.Filters.Get("label")
+	statusFilters := options.Filters.Get("status")
+
+	for _, c := range m.containers {
+		includeContainer := true
+
+		// Check status filters
+		if len(statusFilters) > 0 {
+			statusMatch := false
+			for _, status := range statusFilters {
+				if c.State == status {
+					statusMatch = true
+					break
+				}
+			}
+			if !statusMatch {
+				includeContainer = false
+			}
+		}
+
+		// Check label filters
+		if includeContainer && len(labelFilters) > 0 {
+			for _, filter := range labelFilters {
+				// Simple label filter check (format: "key=value" or just "key")
+				if strings.Contains(filter, "=") {
+					parts := strings.SplitN(filter, "=", 2)
+					key, value := parts[0], parts[1]
+					if labelValue, ok := c.Labels[key]; !ok || labelValue != value {
+						includeContainer = false
+						break
+					}
+				} else {
+					// Just check if label exists
+					if _, ok := c.Labels[filter]; !ok {
+						includeContainer = false
+						break
+					}
+				}
+			}
+		}
+
+		if includeContainer {
+			result = append(result, c)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDockerClient) Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error) {
+	m.mu.Lock()
+	m.eventsStarted = true
+	// Create fresh channels for this Events call
+	eventsChan := make(chan events.Message, 10)
+	errsChan := make(chan error, 10)
+	m.eventsChan = eventsChan
+	m.errsChan = errsChan
+	m.mu.Unlock()
+
+	if m.eventsError != nil {
+		go func() {
+			errsChan <- m.eventsError
+		}()
+	}
+
+	// Handle context cancellation
+	go func() {
+		<-ctx.Done()
+		m.mu.Lock()
+		m.eventsCloseCount++
+		m.mu.Unlock()
+		close(eventsChan)
+		close(errsChan)
+	}()
+
+	return eventsChan, errsChan
+}
+
+func (m *mockDockerClient) Ping(ctx context.Context) (types.Ping, error) {
+	if m.pingError != nil {
+		return types.Ping{}, m.pingError
+	}
+	return types.Ping{APIVersion: "1.41"}, nil
+}
+
+func (m *mockDockerClient) Close() error {
+	return m.closeError
+}
+
+func (m *mockDockerClient) sendEvent(event events.Message) {
+	m.mu.Lock()
+	m.eventsSent = append(m.eventsSent, event)
+	eventsChan := m.eventsChan
+	m.mu.Unlock()
+
+	if eventsChan != nil {
+		select {
+		case eventsChan <- event:
+		default:
+			// Channel full, skip
+		}
+	}
+}
+
+func (m *mockDockerClient) sendError(err error) {
+	m.mu.Lock()
+	errsChan := m.errsChan
+	m.mu.Unlock()
+
+	if errsChan != nil {
+		select {
+		case errsChan <- err:
+		default:
+			// Channel full, skip
+		}
+	}
+}
+
+// Helper function to create test containers
+func createTestContainer(id, name string, labels map[string]string) types.Container {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	return types.Container{
+		ID:     id,
+		Names:  []string{"/" + name},
+		Labels: labels,
+		State:  "running",
+	}
+}
+
+// Helper function to create tsbridge self container
+func createTsbridgeContainer(id string) types.Container {
+	// Note: tsbridge self container should NOT have tsbridge.enabled=true
+	// as it's not a service container
+	labels := map[string]string{
+		"tsbridge.tailscale.oauth_client_id":     "tskey-123",
+		"tsbridge.tailscale.oauth_client_secret": "secret-456",
+		"tsbridge.tailscale.hostname":            "test-bridge",
+	}
+	return types.Container{
+		ID:     id,
+		Names:  []string{"/" + "tsbridge"},
+		Labels: labels,
+		State:  "running",
+	}
+}
+
+// Helper function to create service container
+func createServiceContainer(id, name, backendAddr string) types.Container {
+	return createTestContainer(id, name, map[string]string{
+		"tsbridge.enabled":              "true",
+		"tsbridge.service.name":         name,
+		"tsbridge.service.backend_addr": backendAddr,
+	})
+}
+
+func TestProvider_Load(t *testing.T) {
+	t.Run("success with multiple services", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+
+		// Setup containers
+		tsbridgeContainer := createTsbridgeContainer("tsbridge123")
+		service1 := createServiceContainer("svc1", "api", "localhost:8080")
+		service2 := createServiceContainer("svc2", "web", "localhost:3000")
+
+		mockClient.containers = []types.Container{tsbridgeContainer, service1, service2}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx := context.Background()
+		cfg, err := provider.Load(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Len(t, cfg.Services, 2)
+
+		// Check services were parsed correctly
+		serviceNames := make(map[string]bool)
+		for _, svc := range cfg.Services {
+			serviceNames[svc.Name] = true
+		}
+		assert.True(t, serviceNames["api"])
+		assert.True(t, serviceNames["web"])
+	})
+
+	t.Run("self container not found", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+		// No tsbridge container in list - only service containers
+		mockClient.containers = []types.Container{
+			createServiceContainer("svc1", "api", "localhost:8080"),
+		}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx := context.Background()
+		_, err := provider.Load(ctx)
+
+		assert.Error(t, err)
+		// Now properly returns error about missing tsbridge container
+		assert.Contains(t, err.Error(), "no tsbridge container found")
+	})
+
+	t.Run("docker api error", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+		mockClient.listError = fmt.Errorf("connection refused")
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx := context.Background()
+		_, err := provider.Load(ctx)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "finding tsbridge container")
+	})
+
+	t.Run("no service containers", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+
+		// Only tsbridge container, no services
+		tsbridgeContainer := createTsbridgeContainer("tsbridge123")
+		mockClient.containers = []types.Container{tsbridgeContainer}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx := context.Background()
+		cfg, err := provider.Load(ctx)
+
+		// Docker provider should allow empty services
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Len(t, cfg.Services, 0)
+	})
+
+	t.Run("mixed enabled and disabled containers", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+
+		tsbridgeContainer := createTsbridgeContainer("tsbridge123")
+		enabledService := createServiceContainer("svc1", "api", "localhost:8080")
+		disabledService := createTestContainer("svc2", "disabled", map[string]string{
+			"tsbridge.enabled":      "false",
+			"tsbridge.service.name": "disabled",
+		})
+
+		mockClient.containers = []types.Container{tsbridgeContainer, enabledService, disabledService}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx := context.Background()
+		cfg, err := provider.Load(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Len(t, cfg.Services, 1)
+		assert.Equal(t, "api", cfg.Services[0].Name)
+	})
+
+	t.Run("malformed service labels", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+
+		tsbridgeContainer := createTsbridgeContainer("tsbridge123")
+		badService := createTestContainer("svc1", "bad", map[string]string{
+			"tsbridge.enabled": "true",
+			// Missing required service.name and backend_addr
+		})
+		goodService := createServiceContainer("svc2", "good", "localhost:8080")
+
+		mockClient.containers = []types.Container{tsbridgeContainer, badService, goodService}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx := context.Background()
+		cfg, err := provider.Load(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		// Bad service should be skipped, only good service included
+		assert.Len(t, cfg.Services, 1)
+		assert.Equal(t, "good", cfg.Services[0].Name)
+	})
+}
+
+func TestProvider_Watch_Enhanced(t *testing.T) {
+	t.Run("container start event triggers config reload", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+
+		// Initial state: only tsbridge container
+		tsbridgeContainer := createTsbridgeContainer("tsbridge123")
+		mockClient.containers = []types.Container{tsbridgeContainer}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		// Load initial config to set lastConfig
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		_, err := provider.Load(ctx)
+		require.NoError(t, err)
+
+		configCh, err := provider.Watch(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, configCh)
+
+		// Wait for watch goroutine to start
+		time.Sleep(50 * time.Millisecond)
+
+		// Add a new service container and send start event
+		newService := createServiceContainer("svc1", "api", "localhost:8080")
+		mockClient.mu.Lock()
+		mockClient.containers = append(mockClient.containers, newService)
+		mockClient.mu.Unlock()
+
+		startEvent := events.Message{
+			Type:   "container",
+			Action: "start",
+			Actor: events.Actor{
+				ID: "svc1",
+				Attributes: map[string]string{
+					"name": "api",
+				},
+			},
+		}
+
+		// Send event after a small delay
+		time.Sleep(10 * time.Millisecond)
+		mockClient.sendEvent(startEvent)
+
+		// Should receive new configuration
+		select {
+		case cfg := <-configCh:
+			assert.NotNil(t, cfg)
+			assert.Len(t, cfg.Services, 1)
+			assert.Equal(t, "api", cfg.Services[0].Name)
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("Expected configuration update after container start event")
+		}
+	})
+
+	t.Run("container stop event triggers config reload", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+
+		// Initial state: tsbridge + service container
+		tsbridgeContainer := createTsbridgeContainer("tsbridge123")
+		serviceContainer := createServiceContainer("svc1", "api", "localhost:8080")
+		mockClient.containers = []types.Container{tsbridgeContainer, serviceContainer}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		// Load initial config to set lastConfig
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		_, err := provider.Load(ctx)
+		require.NoError(t, err)
+
+		configCh, err := provider.Watch(ctx)
+		require.NoError(t, err)
+
+		// Wait for watch goroutine to start
+		time.Sleep(50 * time.Millisecond)
+
+		// Remove service container and send stop event
+		mockClient.mu.Lock()
+		mockClient.containers = []types.Container{tsbridgeContainer}
+		mockClient.mu.Unlock()
+
+		stopEvent := events.Message{
+			Type:   "container",
+			Action: "die",
+			Actor: events.Actor{
+				ID: "svc1",
+				Attributes: map[string]string{
+					"name": "api",
+				},
+			},
+		}
+
+		// Send event after a small delay
+		time.Sleep(10 * time.Millisecond)
+		mockClient.sendEvent(stopEvent)
+
+		// Should receive updated configuration (no services)
+		select {
+		case cfg := <-configCh:
+			assert.NotNil(t, cfg)
+			assert.Len(t, cfg.Services, 0)
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("Expected configuration update after container stop event")
+		}
+	})
+
+	t.Run("events stream error handling", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+		mockClient.containers = []types.Container{createTsbridgeContainer("tsbridge123")}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		configCh, err := provider.Watch(ctx)
+		require.NoError(t, err)
+
+		// Wait for events to start
+		time.Sleep(10 * time.Millisecond)
+
+		// Send an error on the events stream
+		mockClient.sendError(fmt.Errorf("docker daemon connection lost"))
+
+		// Watch should handle error gracefully and continue
+		// Channel should remain open
+		select {
+		case <-configCh:
+			// If we get a config, that's fine too
+		case <-time.After(50 * time.Millisecond):
+			// No config received, which is also acceptable for error handling
+		}
+
+		// Channel should still be open
+		select {
+		case <-configCh:
+			t.Fatal("Channel should not be closed after error")
+		default:
+			// Good, channel is still open
+		}
+	})
+
+	t.Run("context cancellation closes channel", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+		mockClient.containers = []types.Container{createTsbridgeContainer("tsbridge123")}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		configCh, err := provider.Watch(ctx)
+		require.NoError(t, err)
+
+		// Wait for events to start
+		time.Sleep(10 * time.Millisecond)
+
+		// Cancel context
+		cancel()
+
+		// Channel should close
+		select {
+		case _, ok := <-configCh:
+			if ok {
+				t.Error("Expected channel to be closed after context cancellation")
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Channel did not close within expected timeframe")
+		}
+	})
+
+	t.Run("non-container events are ignored", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+		mockClient.containers = []types.Container{createTsbridgeContainer("tsbridge123")}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		configCh, err := provider.Watch(ctx)
+		require.NoError(t, err)
+
+		// Wait for events to start
+		time.Sleep(10 * time.Millisecond)
+
+		// Send non-container event
+		networkEvent := events.Message{
+			Type:   "network",
+			Action: "create",
+		}
+
+		mockClient.sendEvent(networkEvent)
+
+		// Should not receive any configuration update
+		select {
+		case <-configCh:
+			t.Fatal("Should not receive config update for non-container events")
+		case <-time.After(50 * time.Millisecond):
+			// Good, no config update received
+		}
+	})
+
+	t.Run("no config change means no update sent", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+
+		tsbridgeContainer := createTsbridgeContainer("tsbridge123")
+		serviceContainer := createServiceContainer("svc1", "api", "localhost:8080")
+		mockClient.containers = []types.Container{tsbridgeContainer, serviceContainer}
+
+		provider := &Provider{
+			client:      mockClient,
+			labelPrefix: "tsbridge",
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Load initial config to set lastConfig
+		_, err := provider.Load(ctx)
+		require.NoError(t, err)
+
+		configCh, err := provider.Watch(ctx)
+		require.NoError(t, err)
+
+		// Wait for events to start
+		time.Sleep(10 * time.Millisecond)
+
+		// Send event for existing container (no config change)
+		restartEvent := events.Message{
+			Type:   "container",
+			Action: "restart",
+			Actor: events.Actor{
+				ID: "svc1",
+				Attributes: map[string]string{
+					"name": "api",
+				},
+			},
+		}
+
+		mockClient.sendEvent(restartEvent)
+
+		// Should not receive configuration update since config didn't change
+		select {
+		case <-configCh:
+			t.Fatal("Should not receive config update when configuration hasn't changed")
+		case <-time.After(50 * time.Millisecond):
+			// Good, no unnecessary update sent
+		}
+	})
+}
+
+func TestProvider_SimpleMethods(t *testing.T) {
+	t.Run("Name returns correct provider name", func(t *testing.T) {
+		provider := &Provider{
+			labelPrefix: "tsbridge",
+		}
+
+		assert.Equal(t, "docker", provider.Name())
+	})
+
+	t.Run("Close calls client close", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+		provider := &Provider{
+			client: mockClient,
+		}
+
+		err := provider.Close()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Close handles client close error", func(t *testing.T) {
+		mockClient := newMockDockerClient()
+		mockClient.closeError = fmt.Errorf("close failed")
+
+		provider := &Provider{
+			client: mockClient,
+		}
+
+		err := provider.Close()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "close failed")
+	})
+
+	t.Run("Close handles nil client", func(t *testing.T) {
+		provider := &Provider{
+			client: nil,
+		}
+
+		err := provider.Close()
+		assert.NoError(t, err)
+	})
+
+	t.Run("getLastConfig returns stored config", func(t *testing.T) {
+		expectedConfig := &config.Config{
+			Services: []config.Service{
+				{Name: "test-service"},
+			},
+		}
+
+		provider := &Provider{
+			lastConfig: expectedConfig,
+		}
+
+		result := provider.getLastConfig()
+		assert.Equal(t, expectedConfig, result)
+	})
+
+	t.Run("getLastConfig is thread-safe", func(t *testing.T) {
+		provider := &Provider{}
+
+		// Test concurrent access
+		done := make(chan bool, 2)
+
+		go func() {
+			for i := 0; i < 100; i++ {
+				provider.getLastConfig()
+			}
+			done <- true
+		}()
+
+		go func() {
+			for i := 0; i < 100; i++ {
+				provider.mu.Lock()
+				provider.lastConfig = &config.Config{}
+				provider.mu.Unlock()
+			}
+			done <- true
+		}()
+
+		// Wait for both goroutines
+		<-done
+		<-done
+
+		// If we get here without panic, the test passed
+	})
+}
+
+func TestProvider_ConfigEqual(t *testing.T) {
+	provider := &Provider{}
+
+	t.Run("nil configs are equal", func(t *testing.T) {
+		assert.True(t, provider.configEqual(nil, nil))
+	})
+
+	t.Run("nil and non-nil configs are not equal", func(t *testing.T) {
+		cfg := &config.Config{}
+		assert.False(t, provider.configEqual(nil, cfg))
+		assert.False(t, provider.configEqual(cfg, nil))
+	})
+
+	t.Run("different service counts are not equal", func(t *testing.T) {
+		cfg1 := &config.Config{
+			Services: []config.Service{{Name: "svc1"}},
+		}
+		cfg2 := &config.Config{
+			Services: []config.Service{{Name: "svc1"}, {Name: "svc2"}},
+		}
+
+		assert.False(t, provider.configEqual(cfg1, cfg2))
+	})
+
+	t.Run("same service names are equal", func(t *testing.T) {
+		cfg1 := &config.Config{
+			Services: []config.Service{{Name: "svc1"}, {Name: "svc2"}},
+		}
+		cfg2 := &config.Config{
+			Services: []config.Service{{Name: "svc2"}, {Name: "svc1"}}, // Different order
+		}
+
+		assert.True(t, provider.configEqual(cfg1, cfg2))
+	})
+
+	t.Run("different service names are not equal", func(t *testing.T) {
+		cfg1 := &config.Config{
+			Services: []config.Service{{Name: "svc1"}},
+		}
+		cfg2 := &config.Config{
+			Services: []config.Service{{Name: "svc2"}},
+		}
+
+		assert.False(t, provider.configEqual(cfg1, cfg2))
+	})
+}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -955,6 +955,13 @@ func TestProvider_Load(t *testing.T) {
 	})
 
 	t.Run("self container not found", func(t *testing.T) {
+		// Mock readFile to simulate hostname reading failure
+		oldReadFile := readFile
+		readFile = func(name string) ([]byte, error) {
+			return nil, fmt.Errorf("file not found")
+		}
+		defer func() { readFile = oldReadFile }()
+
 		mockClient := newMockDockerClient()
 		// No tsbridge container in list - only service containers
 		mockClient.containers = []types.Container{


### PR DESCRIPTION
Switch from polling Docker containers every 5 seconds to using Docker's event stream API for real-time container state monitoring. This provides:
- Immediate response to container events (start, stop, die, pause, unpause)
- Reduced CPU usage by eliminating periodic polling
- More efficient container state tracking
- Automatic reconnection on event stream failures

The implementation introduces a DockerClient interface to improve testability and adds comprehensive unit tests for the new event-based monitoring system.