### PR TITLE
feat: implement whois result caching to reduce goroutines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/docker v28.3.0+incompatible
 	github.com/go-viper/mapstructure/v2 v2.3.0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/knadh/koanf/parsers/toml v0.1.0
 	github.com/knadh/koanf/providers/env v1.1.0
 	github.com/knadh/koanf/providers/file v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N3iBb1Tb4rdcU=
 github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
 github.com/illarion/gonotify/v3 v3.0.2 h1:O7S6vcopHexutmpObkeWsnzMJt/r1hONIEogeVNmJMk=

--- a/internal/middleware/whois_integration_test.go
+++ b/internal/middleware/whois_integration_test.go
@@ -46,7 +46,7 @@ func TestWhois_PreservesAllHeaders(t *testing.T) {
 	}
 
 	// Create middleware
-	m := middleware.Whois(client, true, 0)
+	m := middleware.Whois(client, true, 0, nil)
 
 	// Create a test handler that captures the headers
 	var capturedHeaders http.Header
@@ -128,7 +128,7 @@ func TestWhois_HandlesPartialResponse(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &mockWhoisClient{response: tc.response}
-			m := middleware.Whois(client, true, 0)
+			m := middleware.Whois(client, true, 0, nil)
 
 			var capturedHeaders http.Header
 			handler := m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -198,7 +198,7 @@ func (s *Service) CreateHandler() (http.Handler, error) {
 			// Create a whois client adapter for the tsnet server
 			whoisClient := tailscale.NewWhoisClientAdapter(serviceServer)
 			// Use the whois middleware with cache
-			httpHandler = middleware.Whois(whoisClient, whoisEnabled, whoisTimeout, s.whoisCache)(httpHandler)
+			handler = middleware.Whois(whoisClient, whoisEnabled, whoisTimeout, s.whoisCache)(handler)
 		}
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/jtdowney/tsbridge/internal/config"
 	"github.com/jtdowney/tsbridge/internal/constants"
@@ -25,6 +26,7 @@ type Registry struct {
 	tsServer         *tailscale.Server
 	services         []*Service
 	metricsCollector *metrics.Collector
+	whoisCache       *middleware.WhoisCache
 	mu               sync.Mutex
 }
 
@@ -36,15 +38,17 @@ type Service struct {
 	server           *http.Server
 	tsServer         *tailscale.Server // Reference to Tailscale server for WhoIs
 	metricsCollector *metrics.Collector
+	whoisCache       *middleware.WhoisCache
 	handler          http.Handler // Pre-created handler to catch config errors early
 }
 
 // NewRegistry creates a new service registry
 func NewRegistry(cfg *config.Config, tsServer *tailscale.Server) *Registry {
 	return &Registry{
-		config:   cfg,
-		tsServer: tsServer,
-		services: make([]*Service, 0, len(cfg.Services)),
+		config:     cfg,
+		tsServer:   tsServer,
+		services:   make([]*Service, 0, len(cfg.Services)),
+		whoisCache: middleware.NewWhoisCache(1000, 5*time.Minute),
 	}
 }
 
@@ -106,6 +110,7 @@ func (r *Registry) startService(svcCfg config.Service) (*Service, error) {
 		listener:         listener,
 		tsServer:         r.tsServer,
 		metricsCollector: r.metricsCollector,
+		whoisCache:       r.whoisCache,
 	}
 
 	// Create handler early to catch configuration errors
@@ -192,7 +197,8 @@ func (s *Service) CreateHandler() (http.Handler, error) {
 			}
 			// Create a whois client adapter for the tsnet server
 			whoisClient := tailscale.NewWhoisClientAdapter(serviceServer)
-			handler = middleware.Whois(whoisClient, whoisEnabled, whoisTimeout)(handler)
+			// Use the whois middleware with cache
+			httpHandler = middleware.Whois(whoisClient, whoisEnabled, whoisTimeout, s.whoisCache)(httpHandler)
 		}
 	}
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -576,7 +576,7 @@ func TestServiceWithWhoisMiddleware(t *testing.T) {
 			// If whois is enabled, wrap with middleware
 			if tt.whoisEnabled {
 				whoisAdapter := &MockWhoisAdapter{server: mockTsnetServer}
-				handler = middleware.Whois(whoisAdapter, true, 100*time.Millisecond)(handler)
+				handler = middleware.Whois(whoisAdapter, true, 100*time.Millisecond, nil)(handler)
 			}
 
 			// Create test request


### PR DESCRIPTION
Add LRU cache for whois lookup results with 5-minute TTL and 1000 entry limit. This prevents creating a new goroutine for every request by caching successful whois lookups. The cache is shared across all services in a registry to maximize efficiency.