### PR TITLE
feat: add connection pool metrics collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ When `metrics_addr` is configured, tsbridge exposes metrics at `/metrics`:
 - `tsbridge_active_connections` - Currently active connections
 - `tsbridge_backend_connections_total` - Backend connection attempts
 - `tsbridge_whois_duration_seconds` - Whois lookup latency
+- `tsbridge_connection_pool_active` - Active requests per service (tracks in-flight requests to backends)
+- `tsbridge_connection_pool_idle` - Idle connections (always 0, reserved for future use)
+- `tsbridge_connection_pool_wait` - Requests waiting for connection (always 0, reserved for future use)
 
 ### Logging
 


### PR DESCRIPTION
- Add metrics for active requests (connection pool metrics)
- Create NewHandlerWithMetrics to enable metrics collection
- Collect metrics every 10 seconds via background goroutine
- Track active requests using atomic counter
- Add Close() method to Handler interface for cleanup
- Wire up metrics collection in service layer