### PR TITLE
feat: replace ReadTimeout with ReadHeaderTimeout for long-lived requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ state_dir = "/var/lib/tsbridge"
 
 # Global defaults for all services
 [global]
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 metrics_addr = ":9090"
 
@@ -155,7 +155,7 @@ oauth_tags = ["tag:proxy", "tag:production"]
 ```toml
 [global]
 # Timeouts (Go duration format)
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "15s"
@@ -181,7 +181,7 @@ whois_enabled = true                 # Inject Tailscale identity headers
 whois_timeout = "500ms"              # Override global whois timeout
 
 # Override global settings for this service
-read_timeout = "60s"
+read_header_timeout = "60s"
 write_timeout = "60s"
 access_log = false
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,10 +129,10 @@ All timeouts use Go duration format (e.g., "30s", "1m", "1h30m"):
 
 ```toml
 [global]
-read_timeout = "30s"      # Maximum time to read request headers and body
-write_timeout = "30s"     # Maximum time to write response
-idle_timeout = "120s"     # Maximum time to wait for next request on keep-alive connection
-shutdown_timeout = "15s"  # Maximum time to wait for graceful shutdown
+read_header_timeout = "30s"  # Maximum time to read request headers
+write_timeout = "30s"        # Maximum time to write response
+idle_timeout = "120s"        # Maximum time to wait for next request on keep-alive connection
+shutdown_timeout = "15s"     # Maximum time to wait for graceful shutdown
 ```
 
 ### Backend Connection
@@ -279,7 +279,7 @@ name = "slow-api"
 backend_addr = "localhost:8080"
 
 # Override timeouts for this service
-read_timeout = "60s"
+read_header_timeout = "60s"
 write_timeout = "60s"
 idle_timeout = "300s"
 
@@ -347,7 +347,7 @@ oauth_tags = ["tag:server", "tag:proxy", "tag:prod"]
 
 [global]
 # Conservative timeouts
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "30s"
@@ -387,7 +387,7 @@ name = "admin"
 backend_addr = "127.0.0.1:9000"
 whois_enabled = true
 # Longer timeouts for admin operations
-read_timeout = "5m"
+read_header_timeout = "5m"
 write_timeout = "5m"
 ```
 
@@ -402,7 +402,7 @@ oauth_tags = ["tag:dev", "tag:proxy"]
 
 [global]
 # Shorter timeouts for development
-read_timeout = "5s"
+read_header_timeout = "5s"
 write_timeout = "5s"
 metrics_addr = ":9090"
 
@@ -423,7 +423,7 @@ oauth_tags = ["tag:server", "tag:proxy"]
 state_dir = "/opt/tsbridge/state"
 
 [global]
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 metrics_addr = ":9090"
 
@@ -444,7 +444,7 @@ whois_enabled = true
 name = "external"
 backend_addr = "external-api.example.com:443"
 whois_enabled = false
-read_timeout = "60s"
+read_header_timeout = "60s"
 write_timeout = "60s"
 
 # Internal admin panel

--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -80,7 +80,7 @@ labels:
 ```yaml
 labels:
   # Timeouts
-  - "tsbridge.global.read_timeout=30s"
+  - "tsbridge.global.read_header_timeout=30s"
   - "tsbridge.global.write_timeout=30s"
   - "tsbridge.global.idle_timeout=120s"
   - "tsbridge.global.shutdown_timeout=15s"
@@ -137,7 +137,7 @@ labels:
   - "tsbridge.service.tls_mode=auto" # or "off"
 
   # Service-specific timeouts (override global)
-  - "tsbridge.service.read_timeout=60s"
+  - "tsbridge.service.read_header_timeout=60s"
   - "tsbridge.service.write_timeout=60s"
   - "tsbridge.service.idle_timeout=300s"
   - "tsbridge.service.response_header_timeout=30s"
@@ -242,7 +242,7 @@ services:
 
       # Global defaults
       - "tsbridge.global.metrics_addr=:9090"
-      - "tsbridge.global.read_timeout=30s"
+      - "tsbridge.global.read_header_timeout=30s"
       - "tsbridge.global.access_log=true"
     environment:
       - TS_OAUTH_CLIENT_ID=${TS_OAUTH_CLIENT_ID}
@@ -273,7 +273,7 @@ services:
       - "tsbridge.enabled=true"
       - "tsbridge.service.name=web"
       - "tsbridge.service.backend_addr=web:3000"
-      - "tsbridge.service.read_timeout=60s"
+      - "tsbridge.service.read_header_timeout=60s"
       - "tsbridge.service.access_log=false"
       - "tsbridge.service.downstream_headers.Cache-Control=no-cache"
       - "tsbridge.service.remove_downstream=Server"

--- a/example/docker-compose-labels.yml
+++ b/example/docker-compose-labels.yml
@@ -20,7 +20,7 @@ services:
       
       # Global configuration
       - "tsbridge.global.metrics_addr=:9090"
-      - "tsbridge.global.read_timeout=30s"
+      - "tsbridge.global.read_header_timeout=30s"
       - "tsbridge.global.write_timeout=30s"
       - "tsbridge.global.idle_timeout=120s"
       - "tsbridge.global.access_log=true"
@@ -72,7 +72,7 @@ services:
       - "tsbridge.service.backend_addr=web-backend:8081"
       - "tsbridge.service.whois_enabled=true"
       # Custom timeouts for this service
-      - "tsbridge.service.read_timeout=60s"
+      - "tsbridge.service.read_header_timeout=60s"
       - "tsbridge.service.write_timeout=60s"
       # Disable access logging for this service
       - "tsbridge.service.access_log=false"

--- a/example/tsbridge.toml
+++ b/example/tsbridge.toml
@@ -10,7 +10,7 @@ state_dir = "/var/lib/tsbridge"
 
 [global]
 # Timeouts
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "15s"
@@ -43,5 +43,5 @@ whois_enabled = true
 name = "demo-slow"
 backend_addr = "api-backend:8080"
 whois_enabled = false
-read_timeout = "60s"
+read_header_timeout = "60s"
 write_timeout = "60s"

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -62,7 +62,7 @@ func createTestConfig(t *testing.T) *config.Config {
 		},
 		Global: config.Global{
 			ShutdownTimeout:       config.Duration{Duration: 5 * time.Second},
-			ReadTimeout:           config.Duration{Duration: 30 * time.Second},
+			ReadHeaderTimeout:     config.Duration{Duration: 30 * time.Second},
 			WriteTimeout:          config.Duration{Duration: 30 * time.Second},
 			IdleTimeout:           config.Duration{Duration: 120 * time.Second},
 			ResponseHeaderTimeout: config.Duration{Duration: 10 * time.Second},
@@ -497,10 +497,10 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		// Create config with 3 services, 2 will fail
 		cfg := &config.Config{
 			Global: config.Global{
-				ShutdownTimeout: config.Duration{Duration: 5 * time.Second},
-				ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-				WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-				IdleTimeout:     config.Duration{Duration: 120 * time.Second},
+				ShutdownTimeout:   config.Duration{Duration: 5 * time.Second},
+				ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+				WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+				IdleTimeout:       config.Duration{Duration: 120 * time.Second},
 			},
 			Services: []config.Service{
 				{Name: "service1", BackendAddr: "127.0.0.1:9999", TLSMode: "off"},
@@ -561,10 +561,10 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		// Create config with 2 services that have unreachable backends
 		cfg := &config.Config{
 			Global: config.Global{
-				ShutdownTimeout: config.Duration{Duration: 5 * time.Second},
-				ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-				WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-				IdleTimeout:     config.Duration{Duration: 120 * time.Second},
+				ShutdownTimeout:   config.Duration{Duration: 5 * time.Second},
+				ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+				WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+				IdleTimeout:       config.Duration{Duration: 120 * time.Second},
 			},
 			Services: []config.Service{
 				{Name: "service1", BackendAddr: "127.0.0.1:9999", TLSMode: "off"},
@@ -627,11 +627,11 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		// Create config with metrics and mixed services
 		cfg := &config.Config{
 			Global: config.Global{
-				ShutdownTimeout: config.Duration{Duration: 5 * time.Second},
-				ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-				WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-				IdleTimeout:     config.Duration{Duration: 120 * time.Second},
-				MetricsAddr:     "127.0.0.1:0", // Random port
+				ShutdownTimeout:   config.Duration{Duration: 5 * time.Second},
+				ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+				WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+				IdleTimeout:       config.Duration{Duration: 120 * time.Second},
+				MetricsAddr:       "127.0.0.1:0", // Random port
 			},
 			Services: []config.Service{
 				{Name: "service1", BackendAddr: "127.0.0.1:9999", TLSMode: "off"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,7 @@ type Tailscale struct {
 
 // Global contains global default settings
 type Global struct {
-	ReadTimeout           Duration `mapstructure:"read_timeout"`
+	ReadHeaderTimeout     Duration `mapstructure:"read_header_timeout"`
 	WriteTimeout          Duration `mapstructure:"write_timeout"`
 	IdleTimeout           Duration `mapstructure:"idle_timeout"`
 	ShutdownTimeout       Duration `mapstructure:"shutdown_timeout"`
@@ -68,7 +68,7 @@ type Service struct {
 	WhoisTimeout Duration `mapstructure:"whois_timeout"`
 	TLSMode      string   `mapstructure:"tls_mode"` // "auto" (default), "off"
 	// Optional overrides
-	ReadTimeout           Duration `mapstructure:"read_timeout"`
+	ReadHeaderTimeout     Duration `mapstructure:"read_header_timeout"`
 	WriteTimeout          Duration `mapstructure:"write_timeout"`
 	IdleTimeout           Duration `mapstructure:"idle_timeout"`
 	ResponseHeaderTimeout Duration `mapstructure:"response_header_timeout"`
@@ -318,8 +318,8 @@ func ProcessLoadedConfigWithProvider(cfg *Config, provider string) error {
 // SetDefaults sets default values for any unspecified configuration
 func (c *Config) SetDefaults() {
 	// Set global defaults if not specified
-	if c.Global.ReadTimeout.Duration == 0 {
-		c.Global.ReadTimeout.Duration = constants.DefaultReadTimeout
+	if c.Global.ReadHeaderTimeout.Duration == 0 {
+		c.Global.ReadHeaderTimeout.Duration = constants.DefaultReadHeaderTimeout
 	}
 	if c.Global.WriteTimeout.Duration == 0 {
 		c.Global.WriteTimeout.Duration = constants.DefaultWriteTimeout
@@ -388,8 +388,8 @@ func (c *Config) Normalize() {
 		svc := &c.Services[i]
 
 		// Only copy if the service value is zero (not set)
-		if svc.ReadTimeout.Duration == 0 {
-			svc.ReadTimeout = c.Global.ReadTimeout
+		if svc.ReadHeaderTimeout.Duration == 0 {
+			svc.ReadHeaderTimeout = c.Global.ReadHeaderTimeout
 		}
 		if svc.WriteTimeout.Duration == 0 {
 			svc.WriteTimeout = c.Global.WriteTimeout
@@ -501,8 +501,8 @@ func (c *Config) validateOAuth() error {
 }
 
 func (c *Config) validateGlobal() error {
-	if c.Global.ReadTimeout.Duration <= 0 {
-		return errors.NewValidationError("read_timeout must be positive")
+	if c.Global.ReadHeaderTimeout.Duration <= 0 {
+		return errors.NewValidationError("read_header_timeout must be positive")
 	}
 	if c.Global.WriteTimeout.Duration <= 0 {
 		return errors.NewValidationError("write_timeout must be positive")
@@ -577,8 +577,8 @@ func (c *Config) validateService(svc *Service) error {
 	}
 
 	// Validate service-level overrides if provided
-	if svc.ReadTimeout.Duration < 0 {
-		return errors.NewValidationError("read_timeout must be non-negative")
+	if svc.ReadHeaderTimeout.Duration < 0 {
+		return errors.NewValidationError("read_header_timeout must be non-negative")
 	}
 	if svc.WriteTimeout.Duration < 0 {
 		return errors.NewValidationError("write_timeout must be non-negative")
@@ -636,7 +636,7 @@ func (c *Config) String() string {
 
 	// Global section
 	b.WriteString("\nGlobal:\n")
-	b.WriteString(fmt.Sprintf("  ReadTimeout: %s\n", c.Global.ReadTimeout.Duration))
+	b.WriteString(fmt.Sprintf("  ReadHeaderTimeout: %s\n", c.Global.ReadHeaderTimeout.Duration))
 	b.WriteString(fmt.Sprintf("  WriteTimeout: %s\n", c.Global.WriteTimeout.Duration))
 	b.WriteString(fmt.Sprintf("  IdleTimeout: %s\n", c.Global.IdleTimeout.Duration))
 	b.WriteString(fmt.Sprintf("  ResponseHeaderTimeout: %s\n", c.Global.ResponseHeaderTimeout.Duration))
@@ -662,8 +662,8 @@ func (c *Config) String() string {
 			b.WriteString(fmt.Sprintf("    TLSMode: %s\n", svc.TLSMode))
 		}
 		// Add service-level overrides if set
-		if svc.ReadTimeout.Duration > 0 {
-			b.WriteString(fmt.Sprintf("    ReadTimeout: %s\n", svc.ReadTimeout.Duration))
+		if svc.ReadHeaderTimeout.Duration > 0 {
+			b.WriteString(fmt.Sprintf("    ReadHeaderTimeout: %s\n", svc.ReadHeaderTimeout.Duration))
 		}
 		if svc.WriteTimeout.Duration > 0 {
 			b.WriteString(fmt.Sprintf("    WriteTimeout: %s\n", svc.WriteTimeout.Duration))

--- a/internal/config/fixtures.go
+++ b/internal/config/fixtures.go
@@ -55,7 +55,7 @@ oauth_client_id = "prod-client-id"
 oauth_client_secret = "prod-client-secret"
 
 [global]
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "30s"
@@ -70,7 +70,7 @@ backend_addr = "localhost:8080"
 whois_enabled = true
 whois_timeout = "5s"
 tls_mode = "off"
-read_timeout = "60s"
+read_header_timeout = "60s"
 write_timeout = "60s"
 access_log = false
 funnel_enabled = true
@@ -91,7 +91,7 @@ whois_enabled = false
 					OAuthClientSecret: "prod-client-secret",
 				},
 				Global: Global{
-					ReadTimeout:           Duration{30 * time.Second},
+					ReadHeaderTimeout:     Duration{30 * time.Second},
 					WriteTimeout:          Duration{30 * time.Second},
 					IdleTimeout:           Duration{120 * time.Second},
 					ShutdownTimeout:       Duration{30 * time.Second},
@@ -102,16 +102,16 @@ whois_enabled = false
 				},
 				Services: []Service{
 					{
-						Name:          "api",
-						BackendAddr:   "localhost:8080",
-						WhoisEnabled:  boolPtr(true),
-						WhoisTimeout:  Duration{5 * time.Second},
-						TLSMode:       "off",
-						ReadTimeout:   Duration{60 * time.Second},
-						WriteTimeout:  Duration{60 * time.Second},
-						AccessLog:     boolPtr(false),
-						FunnelEnabled: boolPtr(true),
-						Ephemeral:     false,
+						Name:              "api",
+						BackendAddr:       "localhost:8080",
+						WhoisEnabled:      boolPtr(true),
+						WhoisTimeout:      Duration{5 * time.Second},
+						TLSMode:           "off",
+						ReadHeaderTimeout: Duration{60 * time.Second},
+						WriteTimeout:      Duration{60 * time.Second},
+						AccessLog:         boolPtr(false),
+						FunnelEnabled:     boolPtr(true),
+						Ephemeral:         false,
 						UpstreamHeaders: map[string]string{
 							"X-Custom-Header": "custom-value",
 						},

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,9 +5,9 @@ import "time"
 
 // Timeout constants define the default timeout values used across the application.
 const (
-	// DefaultReadTimeout is the default maximum duration for reading the entire request, including the body.
+	// DefaultReadHeaderTimeout is the default maximum duration for reading the request headers.
 	// A zero or negative value means no timeout.
-	DefaultReadTimeout = 30 * time.Second
+	DefaultReadHeaderTimeout = 30 * time.Second
 
 	// DefaultWriteTimeout is the default timeout for writing the response.
 	// This includes the time from the end of the request reading to the end of the response write.

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -12,8 +12,8 @@ func TestTimeoutConstants(t *testing.T) {
 		expected time.Duration
 	}{
 		{
-			name:     "DefaultReadTimeout",
-			constant: DefaultReadTimeout,
+			name:     "DefaultReadHeaderTimeout",
+			constant: DefaultReadHeaderTimeout,
 			expected: 30 * time.Second,
 		},
 		{

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -166,7 +166,7 @@ func TestParseGlobalConfig(t *testing.T) {
 				"tsbridge.tailscale.oauth_tags":              "tag:proxy, tag:server",
 				"tsbridge.tailscale.state_dir":               "/var/lib/tsbridge",
 				"tsbridge.global.metrics_addr":               ":9090",
-				"tsbridge.global.read_timeout":               "30s",
+				"tsbridge.global.read_header_timeout":        "30s",
 				"tsbridge.global.write_timeout":              "30s",
 				"tsbridge.global.idle_timeout":               "120s",
 				"tsbridge.global.access_log":                 "true",
@@ -188,7 +188,7 @@ func TestParseGlobalConfig(t *testing.T) {
 
 		// Verify global config
 		assert.Equal(t, ":9090", cfg.Global.MetricsAddr)
-		assert.Equal(t, 30*time.Second, cfg.Global.ReadTimeout.Duration)
+		assert.Equal(t, 30*time.Second, cfg.Global.ReadHeaderTimeout.Duration)
 		assert.Equal(t, 30*time.Second, cfg.Global.WriteTimeout.Duration)
 		assert.Equal(t, 120*time.Second, cfg.Global.IdleTimeout.Duration)
 		assert.True(t, *cfg.Global.AccessLog)

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -197,7 +197,7 @@ func (p *Provider) parseGlobalConfig(container *container.Summary, cfg *config.C
 	// Parse global configuration
 	cfg.Global = config.Global{
 		MetricsAddr:              parser.getString("global.metrics_addr"),
-		ReadTimeout:              parser.getDuration("global.read_timeout"),
+		ReadHeaderTimeout:        parser.getDuration("global.read_header_timeout"),
 		WriteTimeout:             parser.getDuration("global.write_timeout"),
 		IdleTimeout:              parser.getDuration("global.idle_timeout"),
 		ShutdownTimeout:          parser.getDuration("global.shutdown_timeout"),
@@ -270,7 +270,7 @@ func (p *Provider) parseServiceConfig(container container.Summary) (*config.Serv
 	svc.FunnelEnabled = parser.getBool("service.funnel_enabled")
 	svc.TLSMode = parser.getString("service.tls_mode")
 	svc.WhoisTimeout = parser.getDuration("service.whois_timeout")
-	svc.ReadTimeout = parser.getDuration("service.read_timeout")
+	svc.ReadHeaderTimeout = parser.getDuration("service.read_header_timeout")
 	svc.WriteTimeout = parser.getDuration("service.write_timeout")
 	svc.IdleTimeout = parser.getDuration("service.idle_timeout")
 	svc.ResponseHeaderTimeout = parser.getDuration("service.response_header_timeout")

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -207,10 +207,10 @@ func TestParseStringSlice(t *testing.T) {
 
 func TestLabelParser(t *testing.T) {
 	labels := map[string]string{
-		"tsbridge.service.name":            "test-service",
-		"tsbridge.service.whois_enabled":   "true",
-		"tsbridge.service.read_timeout":    "30s",
-		"tsbridge.service.remove_upstream": "X-Forwarded-For,X-Real-IP",
+		"tsbridge.service.name":                "test-service",
+		"tsbridge.service.whois_enabled":       "true",
+		"tsbridge.service.read_header_timeout": "30s",
+		"tsbridge.service.remove_upstream":     "X-Forwarded-For,X-Real-IP",
 	}
 
 	parser := &labelParser{
@@ -239,7 +239,7 @@ func TestLabelParser(t *testing.T) {
 	})
 
 	t.Run("getDuration", func(t *testing.T) {
-		result := parser.getDuration("service.read_timeout")
+		result := parser.getDuration("service.read_header_timeout")
 		assert.Equal(t, 30*time.Second, result.Duration)
 
 		result = parser.getDuration("nonexistent")

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -137,10 +137,10 @@ func (r *Registry) startService(svcCfg config.Service) (*Service, error) {
 
 	// Create HTTP server with timeouts
 	svc.server = &http.Server{
-		Handler:      svc.handler,
-		ReadTimeout:  svcCfg.ReadTimeout.Duration,
-		WriteTimeout: svcCfg.WriteTimeout.Duration,
-		IdleTimeout:  svcCfg.IdleTimeout.Duration,
+		Handler:           svc.handler,
+		ReadHeaderTimeout: svcCfg.ReadHeaderTimeout.Duration,
+		WriteTimeout:      svcCfg.WriteTimeout.Duration,
+		IdleTimeout:       svcCfg.IdleTimeout.Duration,
 	}
 
 	// Start serving in background

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -176,10 +176,10 @@ func TestRegistry_StartServices_WithBackendHealthCheck(t *testing.T) {
 					AuthKey: "test-auth-key",
 				},
 				Global: config.Global{
-					ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-					WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-					IdleTimeout:     config.Duration{Duration: 120 * time.Second},
-					ShutdownTimeout: config.Duration{Duration: 10 * time.Second},
+					ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+					WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+					IdleTimeout:       config.Duration{Duration: 120 * time.Second},
+					ShutdownTimeout:   config.Duration{Duration: 10 * time.Second},
 				},
 				Services: tt.services,
 			}
@@ -642,10 +642,10 @@ func TestRegistry_Shutdown(t *testing.T) {
 			AuthKey: "test-auth-key",
 		},
 		Global: config.Global{
-			ReadTimeout:     config.Duration{Duration: 30 * 1000000000}, // 30s
-			WriteTimeout:    config.Duration{Duration: 30 * 1000000000},
-			IdleTimeout:     config.Duration{Duration: 120 * 1000000000},
-			ShutdownTimeout: config.Duration{Duration: 10 * 1000000000},
+			ReadHeaderTimeout: config.Duration{Duration: 30 * 1000000000}, // 30s
+			WriteTimeout:      config.Duration{Duration: 30 * 1000000000},
+			IdleTimeout:       config.Duration{Duration: 120 * 1000000000},
+			ShutdownTimeout:   config.Duration{Duration: 10 * 1000000000},
 		},
 		Services: []config.Service{
 			{
@@ -743,9 +743,9 @@ func TestShutdownWithInflightRequests(t *testing.T) {
 
 			// Create an HTTP server
 			server := &http.Server{
-				Handler:      handler,
-				ReadTimeout:  30 * time.Second,
-				WriteTimeout: 30 * time.Second,
+				Handler:           handler,
+				ReadHeaderTimeout: 30 * time.Second,
+				WriteTimeout:      30 * time.Second,
 			}
 
 			// Start server on a random port
@@ -1004,10 +1004,10 @@ func TestServiceWithRealProxy(t *testing.T) {
 	// Create config
 	cfg := &config.Config{
 		Global: config.Global{
-			ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-			WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-			IdleTimeout:     config.Duration{Duration: 120 * time.Second},
-			ShutdownTimeout: config.Duration{Duration: 10 * time.Second},
+			ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+			WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+			IdleTimeout:       config.Duration{Duration: 120 * time.Second},
+			ShutdownTimeout:   config.Duration{Duration: 10 * time.Second},
 		},
 		Services: []config.Service{
 			{

--- a/test/integration/helpers/fixtures.go
+++ b/test/integration/helpers/fixtures.go
@@ -27,11 +27,11 @@ func NewTestFixture(t *testing.T) *TestFixture {
 				StateDir: t.TempDir(),
 			},
 			Global: config.Global{
-				MetricsAddr:     "localhost:0",
-				ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-				WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-				IdleTimeout:     config.Duration{Duration: 120 * time.Second},
-				ShutdownTimeout: config.Duration{Duration: 10 * time.Second},
+				MetricsAddr:       "localhost:0",
+				ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+				WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+				IdleTimeout:       config.Duration{Duration: 120 * time.Second},
+				ShutdownTimeout:   config.Duration{Duration: 10 * time.Second},
 			},
 			Services: []config.Service{
 				{
@@ -79,7 +79,7 @@ func (f *TestFixture) WithTimeout(name string, duration time.Duration) *TestFixt
 	d := config.Duration{Duration: duration}
 	switch name {
 	case "read":
-		f.cfg.Global.ReadTimeout = d
+		f.cfg.Global.ReadHeaderTimeout = d
 	case "write":
 		f.cfg.Global.WriteTimeout = d
 	case "idle":

--- a/test/integration/helpers/fixtures_test.go
+++ b/test/integration/helpers/fixtures_test.go
@@ -53,7 +53,7 @@ func TestTestFixtureWithTimeout(t *testing.T) {
 		WithTimeout("shutdown", 20*time.Second).
 		Build()
 
-	assert.Equal(t, 5*time.Second, cfg.Global.ReadTimeout.Duration)
+	assert.Equal(t, 5*time.Second, cfg.Global.ReadHeaderTimeout.Duration)
 	assert.Equal(t, 10*time.Second, cfg.Global.WriteTimeout.Duration)
 	assert.Equal(t, 15*time.Second, cfg.Global.IdleTimeout.Duration)
 	assert.Equal(t, 20*time.Second, cfg.Global.ShutdownTimeout.Duration)

--- a/test/integration/helpers/helpers.go
+++ b/test/integration/helpers/helpers.go
@@ -98,11 +98,11 @@ func CreateTestConfig(t *testing.T, serviceName string, backendAddr string) *con
 			StateDir: t.TempDir(),
 		},
 		Global: config.Global{
-			MetricsAddr:     "localhost:0",
-			ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-			WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-			IdleTimeout:     config.Duration{Duration: 120 * time.Second},
-			ShutdownTimeout: config.Duration{Duration: 10 * time.Second},
+			MetricsAddr:       "localhost:0",
+			ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+			WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+			IdleTimeout:       config.Duration{Duration: 120 * time.Second},
+			ShutdownTimeout:   config.Duration{Duration: 10 * time.Second},
 		},
 		Services: []config.Service{
 			{
@@ -126,11 +126,11 @@ func CreateMultiServiceConfig(t *testing.T, services map[string]string) *config.
 			StateDir: t.TempDir(),
 		},
 		Global: config.Global{
-			MetricsAddr:     "localhost:0",
-			ReadTimeout:     config.Duration{Duration: 30 * time.Second},
-			WriteTimeout:    config.Duration{Duration: 30 * time.Second},
-			IdleTimeout:     config.Duration{Duration: 120 * time.Second},
-			ShutdownTimeout: config.Duration{Duration: 10 * time.Second},
+			MetricsAddr:       "localhost:0",
+			ReadHeaderTimeout: config.Duration{Duration: 30 * time.Second},
+			WriteTimeout:      config.Duration{Duration: 30 * time.Second},
+			IdleTimeout:       config.Duration{Duration: 120 * time.Second},
+			ShutdownTimeout:   config.Duration{Duration: 10 * time.Second},
 		},
 	}
 
@@ -306,14 +306,14 @@ oauth_tags = [`
 
 [global]
 metrics_addr = "%s"
-read_timeout = "%s"
+read_header_timeout = "%s"
 write_timeout = "%s" 
 idle_timeout = "%s"
 shutdown_timeout = "%s"
 
 `,
 		cfg.Global.MetricsAddr,
-		cfg.Global.ReadTimeout.Duration,
+		cfg.Global.ReadHeaderTimeout.Duration,
 		cfg.Global.WriteTimeout.Duration,
 		cfg.Global.IdleTimeout.Duration,
 		cfg.Global.ShutdownTimeout.Duration)

--- a/test/integration/performance_test.go
+++ b/test/integration/performance_test.go
@@ -64,7 +64,7 @@ state_dir = "%s"
 
 [global]
 metrics_addr = "localhost:0"
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "5s"
@@ -199,7 +199,7 @@ state_dir = "%s"
 
 [global]
 metrics_addr = "localhost:19200"
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "5s"
@@ -336,7 +336,7 @@ state_dir = "%s"
 
 [global]
 metrics_addr = "localhost:19201"
-read_timeout = "30s"
+read_header_timeout = "30s"
 write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "10s"


### PR DESCRIPTION
BREAKING CHANGE: This replaces the `read_timeout` configuration option with `read_header_timeout` to better support long-lived streaming requests like Jellyfin streams. The new timeout only applies to reading request headers, not the entire request body.

Migration required:
- Update all configuration files to use `read_header_timeout` instead of `read_timeout`
- Update any Docker labels from `tsbridge.*.read_timeout` to `tsbridge.*.read_header_timeout`

The default timeout remains 30s, but now only applies to reading headers. This allows streaming connections to continue indefinitely after headers are successfully read.