### PR TITLE
feat: add flush interval configuration to proxy handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,44 @@ Your services will be available at:
 - `https://api.<your-tailnet-name>.ts.net`
 - `https://web.<your-tailnet-name>.ts.net`
 
+## Streaming Services
+
+tsbridge supports long-lived streaming connections such as media streaming, Server-Sent Events (SSE), and real-time data feeds. Proper configuration is essential for these services to work correctly.
+
+### Key Configuration Options
+
+- **`flush_interval`**: Controls response buffering
+  - `-1ms`: Immediate flushing (no buffering) - recommended for streaming
+  - `100ms`: Flush every 100ms - good for periodic updates
+  - Not set: Default buffering for performance
+  
+- **`write_timeout`**: Controls connection lifetime
+  - `0s`: No timeout - allows indefinite streaming
+  - `30s` (default): Connections terminate after 30 seconds
+  
+### Example: Media Streaming Service
+
+```toml
+[[services]]
+name = "jellyfin"
+backend_addr = "localhost:8096"
+write_timeout = "0s"      # Allow indefinite streaming
+flush_interval = "-1ms"   # Immediate flushing for smooth playback
+idle_timeout = "300s"     # Keep connections alive for 5 minutes
+```
+
+### Example: Server-Sent Events (SSE)
+
+```toml
+[[services]]
+name = "events"
+backend_addr = "localhost:3000"
+write_timeout = "0s"      # SSE connections stay open
+flush_interval = "-1ms"   # Real-time event delivery
+```
+
+For detailed streaming configuration and troubleshooting, see [docs/configuration.md#streaming-services-configuration](docs/configuration.md#streaming-services-configuration).
+
 ## Architecture
 
 ```mermaid

--- a/example/tsbridge.toml
+++ b/example/tsbridge.toml
@@ -45,3 +45,12 @@ backend_addr = "api-backend:8080"
 whois_enabled = false
 read_header_timeout = "60s"
 write_timeout = "60s"
+
+# Example of a streaming service (e.g., SSE, media streaming)
+[[services]]
+name = "demo-stream"
+backend_addr = "api-backend:8080"
+whois_enabled = true
+write_timeout = "0s"      # Disable write timeout for long-lived streams
+flush_interval = "-1ms"   # Immediate flushing for real-time streaming
+idle_timeout = "300s"     # Keep connections alive for 5 minutes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ type Global struct {
 	MetricsAddr           string   `mapstructure:"metrics_addr"`
 	AccessLog             *bool    `mapstructure:"access_log"`      // Enable access logging (default: true)
 	TrustedProxies        []string `mapstructure:"trusted_proxies"` // List of trusted proxy IPs or CIDR ranges
+	FlushInterval         Duration `mapstructure:"flush_interval"`  // Time between flushes (-1ms for immediate)
 	// Transport timeouts
 	DialTimeout              Duration `mapstructure:"dial_timeout"`
 	KeepAliveTimeout         Duration `mapstructure:"keep_alive_timeout"`
@@ -75,6 +76,7 @@ type Service struct {
 	AccessLog             *bool    `mapstructure:"access_log"`     // Override global access_log setting
 	FunnelEnabled         *bool    `mapstructure:"funnel_enabled"` // Expose service via Tailscale Funnel
 	Ephemeral             bool     `mapstructure:"ephemeral"`      // Create ephemeral nodes
+	FlushInterval         Duration `mapstructure:"flush_interval"` // Time between flushes (-1ms for immediate)
 	// Header manipulation
 	UpstreamHeaders   map[string]string `mapstructure:"upstream_headers"`   // Headers to add to upstream requests
 	DownstreamHeaders map[string]string `mapstructure:"downstream_headers"` // Headers to add to downstream responses
@@ -404,6 +406,11 @@ func (c *Config) Normalize() {
 		// Copy access log setting if not set
 		if svc.AccessLog == nil {
 			svc.AccessLog = c.Global.AccessLog
+		}
+
+		// Copy flush interval if not set
+		if svc.FlushInterval.Duration == 0 {
+			svc.FlushInterval = c.Global.FlushInterval
 		}
 	}
 }

--- a/internal/middleware/requestid_integration_test.go
+++ b/internal/middleware/requestid_integration_test.go
@@ -30,7 +30,11 @@ func TestRequestIDIntegration(t *testing.T) {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
-	proxyHandler, err := proxy.NewHandler(backend.URL, transportConfig, nil)
+	proxyHandler, err := proxy.NewHandler(&proxy.HandlerConfig{
+		BackendAddr:     backend.URL,
+		TransportConfig: transportConfig,
+		TrustedProxies:  nil,
+	})
 	if err != nil {
 		t.Fatalf("Failed to create proxy handler: %v", err)
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -183,31 +183,19 @@ func (s *Service) CreateHandler() (http.Handler, error) {
 		transportConfig.ExpectContinueTimeout = s.globalConfig.Global.ExpectContinueTimeout.Duration
 	}
 
-	var handler proxy.Handler
-	var err error
-	if s.metricsCollector != nil {
-		handler, err = proxy.NewHandlerWithMetrics(
-			s.Config.BackendAddr,
-			transportConfig,
-			trustedProxies,
-			s.metricsCollector,
-			s.Config.Name,
-			s.Config.UpstreamHeaders,
-			s.Config.DownstreamHeaders,
-			s.Config.RemoveUpstream,
-			s.Config.RemoveDownstream,
-		)
-	} else {
-		handler, err = proxy.NewHandlerWithHeaders(
-			s.Config.BackendAddr,
-			transportConfig,
-			trustedProxies,
-			s.Config.UpstreamHeaders,
-			s.Config.DownstreamHeaders,
-			s.Config.RemoveUpstream,
-			s.Config.RemoveDownstream,
-		)
-	}
+	// Create proxy handler with unified configuration
+	handler, err := proxy.NewHandler(&proxy.HandlerConfig{
+		BackendAddr:       s.Config.BackendAddr,
+		TransportConfig:   transportConfig,
+		TrustedProxies:    trustedProxies,
+		MetricsCollector:  s.metricsCollector,
+		ServiceName:       s.Config.Name,
+		UpstreamHeaders:   s.Config.UpstreamHeaders,
+		DownstreamHeaders: s.Config.DownstreamHeaders,
+		RemoveUpstream:    s.Config.RemoveUpstream,
+		RemoveDownstream:  s.Config.RemoveDownstream,
+		FlushInterval:     &s.Config.FlushInterval.Duration,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Add FlushInterval field to HandlerConfig for controlling response buffering
- Set default to 0 (standard buffering) when FlushInterval is nil
- Support negative values for immediate flushing
- Add comprehensive tests for flush interval configuration

This allows explicit control over when responses are flushed to clients, which is particularly useful for streaming applications.