### PR TITLE
fix: add WebSocket support to metrics and access log middleware

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,6 +2,7 @@
 package metrics
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log/slog"
@@ -179,6 +180,21 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 		rw.WriteHeader(http.StatusOK)
 	}
 	return rw.ResponseWriter.Write(b)
+}
+
+// Hijack implements the http.Hijacker interface for WebSocket support
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := rw.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, fmt.Errorf("ResponseWriter does not support hijacking")
+}
+
+// Flush implements the http.Flusher interface for streaming support
+func (rw *responseWriter) Flush() {
+	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }
 
 // Middleware returns HTTP middleware that records metrics for requests


### PR DESCRIPTION
Both the metrics and access log middleware were wrapping http.ResponseWriter without implementing the http.Hijacker interface, which prevented WebSocket connections from being upgraded properly.

This fix adds:
- Hijack() method to both middleware response writers for WebSocket support
- Flush() method to both middleware response writers for streaming support
- Comprehensive tests for WebSocket and streaming functionality

The middleware now properly delegates hijacking and flushing to the underlying ResponseWriter, allowing WebSocket connections to work through the entire middleware chain.