### PR TITLE
fix: disable compression and HTTP/2 in proxy transport

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -320,7 +320,8 @@ func createProxyTransport(backendAddr string, config *TransportConfig) *http.Tra
 			}
 			return d.DialContext(ctx, network, addr)
 		},
-		ForceAttemptHTTP2:     true,
+		DisableCompression:    true,
+		ForceAttemptHTTP2:     false,
 		MaxIdleConns:          100,
 		MaxConnsPerHost:       50,
 		MaxIdleConnsPerHost:   10,


### PR DESCRIPTION
- Set DisableCompression to true to prevent the Go HTTP client from automatically compressing/decompressing requests and responses. This allows the proxy to pass through compressed content as-is from the backend, preserving the original encoding.

- Set ForceAttemptHTTP2 to false to disable automatic HTTP/2 upgrades. This ensures more predictable behavior and better compatibility with various backend services that may not fully support HTTP/2.

These changes improve proxy transparency and compatibility.