### PR TITLE
refactor: consolidate metrics server constructor functions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -126,7 +126,7 @@ func (a *App) setupMetrics() error {
 	a.registry.SetMetricsCollector(collector)
 
 	// Create metrics server (but don't start it yet)
-	a.metricsServer = metrics.NewServerWithRegistry(a.cfg.Global.MetricsAddr, reg, a.cfg.Global.MetricsReadHeaderTimeout.Duration)
+	a.metricsServer = metrics.NewServer(a.cfg.Global.MetricsAddr, reg, a.cfg.Global.MetricsReadHeaderTimeout.Duration)
 
 	return nil
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -965,7 +965,7 @@ func TestMetricsServerIntegration(t *testing.T) {
 	err := collector.Register(reg)
 	require.NoError(t, err)
 
-	server := metrics.NewServerWithRegistry("127.0.0.1:0", reg, 5*time.Second)
+	server := metrics.NewServer("127.0.0.1:0", reg, 5*time.Second)
 
 	// Start the server
 	ctx := context.Background()

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -239,16 +239,8 @@ type Server struct {
 	readHeaderTimeout time.Duration
 }
 
-// NewServer creates a new metrics server
-func NewServer(addr string) *Server {
-	return &Server{
-		addr:     addr,
-		registry: prometheus.DefaultRegisterer.(*prometheus.Registry),
-	}
-}
-
-// NewServerWithRegistry creates a new metrics server with a custom registry
-func NewServerWithRegistry(addr string, registry *prometheus.Registry, readHeaderTimeout time.Duration) *Server {
+// NewServer creates a new metrics server with a custom registry
+func NewServer(addr string, registry *prometheus.Registry, readHeaderTimeout time.Duration) *Server {
 	return &Server{
 		addr:              addr,
 		registry:          registry,


### PR DESCRIPTION
- Merge NewServer and NewServerWithRegistry into a single NewServer function
- Update all callers to use the consolidated constructor
- Simplify test setup to use the new function signature