### PR TITLE
feat: add per-service tag support with OAuth improvements

### DIFF
--- a/deployments/systemd/README.md
+++ b/deployments/systemd/README.md
@@ -117,16 +117,16 @@ Your main configuration should be in `/etc/tsbridge/config.toml`. Make sure to u
 [tailscale]
 # Option 1: Minimal config - will use TS_OAUTH_CLIENT_ID and TS_OAUTH_CLIENT_SECRET env vars
 state_dir = "/var/lib/tsbridge"
-# OAuth tags are REQUIRED when using OAuth authentication
-oauth_tags = ["tag:server", "tag:proxy"]
 
 # Option 2: Explicitly specify which env vars to use
 # oauth_client_id_env = "CUSTOM_OAUTH_ID"
 # oauth_client_secret_env = "CUSTOM_OAUTH_SECRET"
-# oauth_tags = ["tag:server", "tag:proxy"]
 
 # Option 3: Use auth key instead of OAuth
 # auth_key_env = "TS_AUTHKEY"
+
+# Default tags for all services (when using OAuth, your service must have tags)
+default_tags = ["tag:server", "tag:proxy"]
 
 [global]
 metrics_addr = ":9090"

--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -16,14 +16,14 @@ services:
       # Global configuration
       - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
       - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
-      - "tsbridge.tailscale.oauth_tags=tag:server"  # Required when using OAuth
       - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+      - "tsbridge.tailscale.default_tags=tag:server,tag:proxy"
       - "tsbridge.global.metrics_addr=:9090"
     environment:
       - TS_OAUTH_CLIENT_ID=${TS_OAUTH_CLIENT_ID}
       - TS_OAUTH_CLIENT_SECRET=${TS_OAUTH_CLIENT_SECRET}
     ports:
-      - "9090:9090"  # Metrics port
+      - "9090:9090" # Metrics port
 
   api:
     image: myapp:latest
@@ -68,11 +68,11 @@ labels:
   - "tsbridge.tailscale.auth_key_env=<env_var>"
   - "tsbridge.tailscale.auth_key_file=<file_path>"
 
-  # OAuth tags (comma-separated) - REQUIRED when using OAuth
-  - "tsbridge.tailscale.oauth_tags=tag:server,tag:proxy"
-
   # State directory
   - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+
+  # Default tags for all services (comma-separated)
+  - "tsbridge.tailscale.default_tags=tag:tsbridge,tag:proxy"
 ```
 
 #### Global Defaults
@@ -85,7 +85,6 @@ labels:
   - "tsbridge.global.idle_timeout=120s"
   - "tsbridge.global.shutdown_timeout=15s"
   - "tsbridge.global.response_header_timeout=10s"
-
 
   # Metrics
   - "tsbridge.global.metrics_addr=:9090"
@@ -129,6 +128,9 @@ labels:
 
 ```yaml
 labels:
+  # Service-specific tags (comma-separated) - overrides tailscale.default_tags
+  - "tsbridge.service.tags=tag:api,tag:prod"
+
   # Whois configuration
   - "tsbridge.service.whois_enabled=true"
   - "tsbridge.service.whois_timeout=2s"
@@ -141,7 +143,6 @@ labels:
   - "tsbridge.service.write_timeout=60s"
   - "tsbridge.service.idle_timeout=300s"
   - "tsbridge.service.response_header_timeout=30s"
-
 
   # Access logging (override global)
   - "tsbridge.service.access_log=false"
@@ -202,7 +203,6 @@ When running in Docker, use `tsbridge.service.port` instead of `tsbridge.service
 
 # Unix socket (requires volume mount)
 - "tsbridge.service.backend_addr=unix:///var/run/app.sock"
-
 # Auto-detection (uses first exposed port)
 # No backend labels needed if container exposes a port
 ```
@@ -249,8 +249,8 @@ services:
       # Tailscale configuration
       - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
       - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
-      - "tsbridge.tailscale.oauth_tags=tag:server,tag:proxy"
       - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+      - "tsbridge.tailscale.default_tags=tag:server,tag:proxy"
 
       # Global defaults
       - "tsbridge.global.metrics_addr=:9090"

--- a/example/tsbridge.toml
+++ b/example/tsbridge.toml
@@ -4,11 +4,12 @@
 # OAuth credentials are provided via environment variables
 oauth_client_id_env = "TS_OAUTH_CLIENT_ID"
 oauth_client_secret_env = "TS_OAUTH_CLIENT_SECRET"
-# OAuth tags are REQUIRED when using OAuth authentication
-oauth_tags = ["tag:server"]
 state_dir = "/var/lib/tsbridge"
+# Default tags for all services (can be overridden per-service)
+default_tags = ["tag:tsbridge", "tag:proxy"]
 
 [global]
+
 # Timeouts
 read_header_timeout = "30s"
 write_timeout = "30s"
@@ -25,18 +26,19 @@ metrics_addr = ":9090"
 # Enable access logging
 access_log = true
 
-# API service
+# API service (uses default tags)
 [[services]]
 name = "demo-api"
 backend_addr = "api-backend:8080"
 whois_enabled = true
 whois_timeout = "500ms"
 
-# Web service
+# Web service with custom tags
 [[services]]
 name = "demo-web"
 backend_addr = "web-backend:8081"
 whois_enabled = true
+tags = ["tag:web", "tag:frontend"]
 
 # Example of a service with custom timeouts
 [[services]]

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -834,6 +834,7 @@ func TestAppSetupMetrics(t *testing.T) {
 						Name:         "test-service",
 						BackendAddr:  "unix:///tmp/test.sock",
 						WhoisTimeout: config.Duration{Duration: 5 * time.Second},
+						Tags:         []string{"tag:test"},
 					},
 				},
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,6 +60,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -98,6 +99,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(tmpDir, "config.toml")
@@ -122,6 +124,7 @@ oauth_client_secret = "test-secret"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -159,6 +162,7 @@ read_header_timeout = "60s"
 name = "test-service"
 backend_addr = "localhost:8080"
 read_header_timeout = "90s"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -186,6 +190,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -227,6 +232,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(tmpDir, "config.toml")
@@ -265,6 +271,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(tmpDir, "config.toml")
@@ -295,6 +302,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(tmpDir, "config.toml")
@@ -318,6 +326,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -346,6 +355,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -374,6 +384,7 @@ write_timeout = "40s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -404,6 +415,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -426,6 +438,7 @@ read_header_timeout = "30s"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 
 		tmpFile := filepath.Join(t.TempDir(), "config.toml")
@@ -512,50 +525,6 @@ func TestResolveSecrets(t *testing.T) {
 		}
 	})
 }
-func TestValidateAuthKeySources(t *testing.T) {
-	tests := []struct {
-		name      string
-		tailscale Tailscale
-		wantErr   bool
-		errMsg    string
-	}{
-		{
-			name: "valid AuthKey",
-			tailscale: Tailscale{
-				AuthKey: "test-auth-key",
-			},
-			wantErr: false,
-		},
-		{
-			name: "AuthKey with oauth_tags",
-			tailscale: Tailscale{
-				AuthKey:   "test-auth-key",
-				OAuthTags: []string{"tag:tsbridge"},
-			},
-			wantErr: true,
-			errMsg:  "oauth_tags can only be used with OAuth authentication",
-		},
-		{
-			name: "empty AuthKey is valid",
-			tailscale: Tailscale{
-				AuthKey: "",
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateAuthKeySources(tt.tailscale)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("validateAuthKeySources() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
-				t.Errorf("validateAuthKeySources() error = %v, want error containing %v", err, tt.errMsg)
-			}
-		})
-	}
-}
 
 func TestValidateOAuthSources(t *testing.T) {
 	tests := []struct {
@@ -591,11 +560,10 @@ func TestValidateOAuthSources(t *testing.T) {
 			errMsg:  "OAuth client secret must be provided",
 		},
 		{
-			name: "OAuth with tags",
+			name: "OAuth valid",
 			tailscale: Tailscale{
 				OAuthClientID:     "test-id",
 				OAuthClientSecret: "test-secret",
-				OAuthTags:         []string{"tag:tsbridge"},
 			},
 			wantErr: false,
 		},
@@ -703,6 +671,7 @@ func TestValidate(t *testing.T) {
 						BackendAddr:  "127.0.0.1:8080",
 						WhoisEnabled: &trueVal,
 						WhoisTimeout: makeDuration(1 * time.Second),
+						Tags:         []string{"tag:test"},
 					},
 				},
 			},
@@ -761,10 +730,12 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8081",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -787,6 +758,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -809,6 +781,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -831,6 +804,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "not-a-valid-address",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -853,6 +827,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -876,6 +851,7 @@ func TestValidate(t *testing.T) {
 						Name:         "api",
 						BackendAddr:  "unix:///var/run/api.sock",
 						WhoisEnabled: &falseVal,
+						Tags:         []string{"tag:test"},
 					},
 				},
 			},
@@ -899,6 +875,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -922,6 +899,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -945,6 +923,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -968,6 +947,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -991,6 +971,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -1017,52 +998,7 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: "",
 		},
-		{
-			name: "oauth_tags with OAuth is valid",
-			config: &Config{
-				Tailscale: Tailscale{
-					OAuthClientID:     "test-id",
-					OAuthClientSecret: "test-secret",
-					OAuthTags:         []string{"tag:tsbridge", "tag:role=proxy"},
-				},
-				Global: Global{
-					ReadHeaderTimeout: makeDuration(5 * time.Second),
-					WriteTimeout:      makeDuration(10 * time.Second),
-					IdleTimeout:       makeDuration(120 * time.Second),
-					ShutdownTimeout:   makeDuration(15 * time.Second),
-				},
-				Services: []Service{
-					{
-						Name:        "api",
-						BackendAddr: "127.0.0.1:8080",
-					},
-				},
-			},
-			wantErr: "",
-		},
 
-		{
-			name: "oauth_tags with AuthKey is invalid",
-			config: &Config{
-				Tailscale: Tailscale{
-					AuthKey:   "test-auth-key",
-					OAuthTags: []string{"tag:tsbridge"},
-				},
-				Global: Global{
-					ReadHeaderTimeout: makeDuration(5 * time.Second),
-					WriteTimeout:      makeDuration(10 * time.Second),
-					IdleTimeout:       makeDuration(120 * time.Second),
-					ShutdownTimeout:   makeDuration(15 * time.Second),
-				},
-				Services: []Service{
-					{
-						Name:        "api",
-						BackendAddr: "127.0.0.1:8080",
-					},
-				},
-			},
-			wantErr: "oauth_tags can only be used with OAuth",
-		},
 		{
 			name: "valid state directory",
 			config: &Config{
@@ -1081,6 +1017,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -1104,6 +1041,7 @@ func TestValidate(t *testing.T) {
 					{
 						Name:        "api",
 						BackendAddr: "127.0.0.1:8080",
+						Tags:        []string{"tag:test"},
 					},
 				},
 			},
@@ -1127,6 +1065,7 @@ func TestValidate(t *testing.T) {
 						Name:          "api",
 						BackendAddr:   "127.0.0.1:8080",
 						FunnelEnabled: &trueVal,
+						Tags:          []string{"tag:test"},
 					},
 				},
 			},
@@ -1453,12 +1392,10 @@ func TestTailscaleString(t *testing.T) {
 			ts: Tailscale{
 				OAuthClientID:     "client-123",
 				OAuthClientSecret: "secret",
-				OAuthTags:         []string{"tag:server", "tag:prod"},
 				StateDir:          "/var/lib/tsbridge",
 			},
 			contains: []string{
 				"OAuthClientID: client-123",
-				"OAuthTags: [tag:server tag:prod]",
 				"StateDir: /var/lib/tsbridge",
 			},
 		},
@@ -1997,6 +1934,7 @@ flush_interval = "100ms"
 [[services]]
 name = "test"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `,
 			checkGlobal:    true,
 			expectedGlobal: 100 * time.Millisecond,
@@ -2012,6 +1950,7 @@ oauth_client_secret = "test-secret"
 name = "test"
 backend_addr = "localhost:8080"
 flush_interval = "200ms"
+tags = ["tag:test"]
 `,
 			checkService: true,
 			expectedSvc:  200 * time.Millisecond,
@@ -2029,6 +1968,7 @@ flush_interval = "300ms"
 [[services]]
 name = "test"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `,
 			checkService: true,
 			expectedSvc:  300 * time.Millisecond,
@@ -2047,6 +1987,7 @@ flush_interval = "300ms"
 name = "test"
 backend_addr = "localhost:8080"
 flush_interval = "50ms"
+tags = ["tag:test"]
 `,
 			checkGlobal:    true,
 			checkService:   true,
@@ -2064,6 +2005,7 @@ oauth_client_secret = "test-secret"
 name = "streaming"
 backend_addr = "localhost:8080"
 flush_interval = "-1ms"
+tags = ["tag:test"]
 `,
 			checkService: true,
 			expectedSvc:  -1 * time.Millisecond,
@@ -2079,6 +2021,7 @@ oauth_client_secret = "test-secret"
 name = "test"
 backend_addr = "localhost:8080"
 flush_interval = "0s"
+tags = ["tag:test"]
 `,
 			checkService: true,
 			expectedSvc:  0,
@@ -2143,6 +2086,227 @@ func TestFlushIntervalNormalization(t *testing.T) {
 
 	// Service without override should inherit global value
 	assert.Equal(t, 100*time.Millisecond, cfg.Services[1].FlushInterval.Duration)
+}
+
+func TestTagsConfiguration(t *testing.T) {
+	t.Run("global default tags", func(t *testing.T) {
+		configContent := `
+[tailscale]
+oauth_client_id = "test-id"
+oauth_client_secret = "test-secret"
+default_tags = ["tag:web", "tag:prod"]
+
+[global]
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		cfg, err := Load(tmpFile)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, []string{"tag:web", "tag:prod"}, cfg.Tailscale.DefaultTags)
+	})
+
+	t.Run("service-specific tags", func(t *testing.T) {
+		configContent := `
+[tailscale]
+oauth_client_id = "test-id"
+oauth_client_secret = "test-secret"
+
+[global]
+default_tags = ["tag:default"]
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+tags = ["tag:api", "tag:prod"]
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		cfg, err := Load(tmpFile)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, []string{"tag:api", "tag:prod"}, cfg.Services[0].Tags)
+	})
+
+	t.Run("service inherits global tags when not specified", func(t *testing.T) {
+		configContent := `
+[tailscale]
+oauth_client_id = "test-id"
+oauth_client_secret = "test-secret"
+default_tags = ["tag:global", "tag:prod"]
+
+[global]
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		cfg, err := Load(tmpFile)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		// After normalization, service should inherit global tags
+		assert.Equal(t, []string{"tag:global", "tag:prod"}, cfg.Services[0].Tags)
+	})
+
+	t.Run("service keeps its own tags when specified", func(t *testing.T) {
+		configContent := `
+[tailscale]
+oauth_client_id = "test-id"
+oauth_client_secret = "test-secret"
+
+[global]
+default_tags = ["tag:global"]
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+tags = ["tag:api", "tag:special"]
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		cfg, err := Load(tmpFile)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		// Service should keep its own tags, not inherit global
+		assert.Equal(t, []string{"tag:api", "tag:special"}, cfg.Services[0].Tags)
+	})
+
+	t.Run("error when service has empty tags array", func(t *testing.T) {
+		configContent := `
+[tailscale]
+oauth_client_id = "test-id"
+oauth_client_secret = "test-secret"
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+tags = []
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		_, err := Load(tmpFile)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must have at least one tag")
+	})
+
+	t.Run("error when no tags configured anywhere", func(t *testing.T) {
+		configContent := `
+[tailscale]
+oauth_client_id = "test-id"
+oauth_client_secret = "test-secret"
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		_, err := Load(tmpFile)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must have at least one tag")
+	})
+
+	t.Run("tags required when using OAuth", func(t *testing.T) {
+		configContent := `
+[tailscale]
+oauth_client_id = "test-id"
+oauth_client_secret = "test-secret"
+default_tags = ["tag:web"]
+
+[global]
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		cfg, err := Load(tmpFile)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		// Service should have inherited tags
+		assert.Equal(t, []string{"tag:web"}, cfg.Services[0].Tags)
+	})
+
+	t.Run("tags not required when using auth key", func(t *testing.T) {
+		configContent := `
+[tailscale]
+auth_key = "test-key"
+
+[[services]]
+name = "api"
+backend_addr = "localhost:8080"
+`
+		tmpFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(configContent), 0644))
+
+		cfg, err := Load(tmpFile)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		// No error expected when using auth key without tags
+	})
+}
+
+func TestTagsInheritance(t *testing.T) {
+	t.Run("multiple services with mixed tag configuration", func(t *testing.T) {
+		cfg := &Config{
+			Tailscale: Tailscale{
+				OAuthClientID:     "test-id",
+				OAuthClientSecret: "test-secret",
+				DefaultTags:       []string{"tag:global", "tag:default"},
+			},
+			Global: Global{
+				ReadHeaderTimeout: makeDuration(30 * time.Second),
+				WriteTimeout:      makeDuration(30 * time.Second),
+				IdleTimeout:       makeDuration(120 * time.Second),
+				ShutdownTimeout:   makeDuration(30 * time.Second),
+			},
+			Services: []Service{
+				{
+					Name:        "api",
+					BackendAddr: "localhost:8080",
+					Tags:        []string{"tag:api", "tag:custom"},
+				},
+				{
+					Name:        "web",
+					BackendAddr: "localhost:8081",
+					// No tags specified, should inherit
+				},
+			},
+		}
+
+		cfg.SetDefaults()
+		cfg.Normalize()
+
+		// First service keeps its own tags
+		assert.Equal(t, []string{"tag:api", "tag:custom"}, cfg.Services[0].Tags)
+
+		// Second service inherits global tags
+		assert.Equal(t, []string{"tag:global", "tag:default"}, cfg.Services[1].Tags)
+
+		// Validate should pass
+		err := cfg.Validate()
+		assert.NoError(t, err)
+	})
 }
 
 func TestZeroDurationHandling(t *testing.T) {

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -36,6 +36,7 @@ oauth_client_secret = "test-client-secret"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `,
 			ExpectedConfig: &Config{
 				Tailscale: Tailscale{
@@ -79,6 +80,7 @@ write_timeout = "60s"
 access_log = false
 funnel_enabled = true
 ephemeral = false
+tags = ["tag:test"]
 
 [[services.upstream_headers]]
 name = "X-Custom-Header"
@@ -88,6 +90,7 @@ value = "custom-value"
 name = "web"
 backend_addr = "localhost:3000"
 whois_enabled = false
+tags = ["tag:test"]
 `,
 			ExpectedConfig: &Config{
 				Tailscale: Tailscale{
@@ -119,11 +122,13 @@ whois_enabled = false
 						UpstreamHeaders: map[string]string{
 							"X-Custom-Header": "custom-value",
 						},
+						Tags: []string{"tag:test"},
 					},
 					{
 						Name:         "web",
 						BackendAddr:  "localhost:3000",
 						WhoisEnabled: boolPtr(false),
+						Tags:         []string{"tag:test"},
 					},
 				},
 			},
@@ -139,6 +144,7 @@ oauth_client_secret_env = "TEST_OAUTH_SECRET"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `,
 			ExpectedConfig: &Config{
 				Tailscale: Tailscale{
@@ -164,6 +170,7 @@ oauth_client_secret = "test-secret"
 [[services]]
 name = "unix-service"
 backend_addr = "unix:///var/run/app.sock"
+tags = ["tag:test"]
 `,
 			ExpectedConfig: &Config{
 				Tailscale: Tailscale{
@@ -189,6 +196,7 @@ backend_addr = "unix:///var/run/app.sock"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `,
 			ExpectError: "oauth_client_id and oauth_client_secret are required",
 		},
@@ -853,6 +861,7 @@ oauth_client_secret = "test-secret"
 [[services]]
 name = "test-service"
 backend_addr = "localhost:8080"
+tags = ["tag:test"]
 `
 				provider, cleanup := tt.createProvider(t, content)
 				defer cleanup()

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -25,17 +25,16 @@ func (r RedactedString) Format(f fmt.State, verb rune) {
 
 // RedactedTailscale is a version of Tailscale config with sensitive fields redacted
 type RedactedTailscale struct {
-	OAuthClientID         string   `json:"oauth_client_id,omitempty"`
-	OAuthClientIDEnv      string   `json:"oauth_client_id_env,omitempty"`
-	OAuthClientIDFile     string   `json:"oauth_client_id_file,omitempty"`
-	OAuthClientSecret     string   `json:"oauth_client_secret,omitempty"`
-	OAuthClientSecretEnv  string   `json:"oauth_client_secret_env,omitempty"`
-	OAuthClientSecretFile string   `json:"oauth_client_secret_file,omitempty"`
-	AuthKey               string   `json:"auth_key,omitempty"`
-	AuthKeyEnv            string   `json:"auth_key_env,omitempty"`
-	AuthKeyFile           string   `json:"auth_key_file,omitempty"`
-	OAuthTags             []string `json:"oauth_tags,omitempty"`
-	StateDir              string   `json:"state_dir,omitempty"`
+	OAuthClientID         string `json:"oauth_client_id,omitempty"`
+	OAuthClientIDEnv      string `json:"oauth_client_id_env,omitempty"`
+	OAuthClientIDFile     string `json:"oauth_client_id_file,omitempty"`
+	OAuthClientSecret     string `json:"oauth_client_secret,omitempty"`
+	OAuthClientSecretEnv  string `json:"oauth_client_secret_env,omitempty"`
+	OAuthClientSecretFile string `json:"oauth_client_secret_file,omitempty"`
+	AuthKey               string `json:"auth_key,omitempty"`
+	AuthKeyEnv            string `json:"auth_key_env,omitempty"`
+	AuthKeyFile           string `json:"auth_key_file,omitempty"`
+	StateDir              string `json:"state_dir,omitempty"`
 }
 
 // RedactedConfig is a version of Config with sensitive fields redacted for safe logging
@@ -60,7 +59,6 @@ func (c *Config) Redacted() *RedactedConfig {
 			OAuthClientSecretFile: c.Tailscale.OAuthClientSecretFile,
 			AuthKeyEnv:            c.Tailscale.AuthKeyEnv,
 			AuthKeyFile:           c.Tailscale.AuthKeyFile,
-			OAuthTags:             c.Tailscale.OAuthTags,
 			StateDir:              c.Tailscale.StateDir,
 		},
 		Global:   c.Global,

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -165,8 +165,8 @@ func TestParseGlobalConfig(t *testing.T) {
 			Labels: map[string]string{
 				"tsbridge.tailscale.oauth_client_id_env":     "TS_OAUTH_CLIENT_ID",
 				"tsbridge.tailscale.oauth_client_secret_env": "TS_OAUTH_CLIENT_SECRET",
-				"tsbridge.tailscale.oauth_tags":              "tag:proxy, tag:server",
 				"tsbridge.tailscale.state_dir":               "/var/lib/tsbridge",
+				"tsbridge.tailscale.default_tags":            "tag:proxy,tag:server",
 				"tsbridge.global.metrics_addr":               ":9090",
 				"tsbridge.global.read_header_timeout":        "30s",
 				"tsbridge.global.write_timeout":              "30s",
@@ -186,8 +186,8 @@ func TestParseGlobalConfig(t *testing.T) {
 		assert.Equal(t, "", cfg.Tailscale.OAuthClientSecret)
 		assert.Equal(t, "TS_OAUTH_CLIENT_ID", cfg.Tailscale.OAuthClientIDEnv)
 		assert.Equal(t, "TS_OAUTH_CLIENT_SECRET", cfg.Tailscale.OAuthClientSecretEnv)
-		assert.Equal(t, []string{"tag:proxy", "tag:server"}, cfg.Tailscale.OAuthTags)
 		assert.Equal(t, "/var/lib/tsbridge", cfg.Tailscale.StateDir)
+		assert.Equal(t, []string{"tag:proxy", "tag:server"}, cfg.Tailscale.DefaultTags)
 
 		// Verify global config
 		assert.Equal(t, ":9090", cfg.Global.MetricsAddr)
@@ -908,6 +908,7 @@ func createTsbridgeContainer(id string) container.Summary {
 		"tsbridge.tailscale.oauth_client_id":     "tskey-123",
 		"tsbridge.tailscale.oauth_client_secret": "secret-456",
 		"tsbridge.tailscale.hostname":            "test-bridge",
+		"tsbridge.tailscale.default_tags":        "tag:test,tag:docker",
 	}
 	return container.Summary{
 		ID:     id,

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -191,7 +191,7 @@ func (p *Provider) parseGlobalConfig(container *container.Summary, cfg *config.C
 		AuthKeyEnv:            parser.getString("tailscale.auth_key_env"),
 		AuthKeyFile:           parser.getString("tailscale.auth_key_file"),
 		StateDir:              parser.getString("tailscale.state_dir"),
-		OAuthTags:             parser.getStringSlice("tailscale.oauth_tags", ","),
+		DefaultTags:           parser.getStringSlice("tailscale.default_tags", ","),
 	}
 
 	// Parse global configuration
@@ -266,6 +266,7 @@ func (p *Provider) parseServiceConfig(container container.Summary) (*config.Serv
 	svc.BackendAddr = backendAddr
 
 	// Parse configuration
+	svc.Tags = parser.getStringSlice("service.tags", ",")
 	svc.WhoisEnabled = parser.getBool("service.whois_enabled")
 	svc.AccessLog = parser.getBool("service.access_log")
 	svc.FunnelEnabled = parser.getBool("service.funnel_enabled")

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -644,6 +644,7 @@ func getDockerParsedGlobalFields() map[string]bool {
 		"global.expect_continue_timeout":     true,
 		"global.metrics_read_header_timeout": true,
 		"global.flush_interval":              true,
+		"global.default_tags":                true,
 	}
 }
 
@@ -668,5 +669,6 @@ func getDockerParsedServiceFields() map[string]bool {
 		"service.downstream_headers":      true,
 		"service.remove_upstream":         true,
 		"service.remove_downstream":       true,
+		"service.tags":                    true,
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -112,7 +112,7 @@ func (r *Registry) StartServices() error {
 func (r *Registry) startService(svcCfg config.Service) (*Service, error) {
 
 	// Create listener for this service
-	listener, err := r.tsServer.ListenWithService(svcCfg, svcCfg.TLSMode, svcCfg.FunnelEnabled != nil && *svcCfg.FunnelEnabled)
+	listener, err := r.tsServer.Listen(svcCfg, svcCfg.TLSMode, svcCfg.FunnelEnabled != nil && *svcCfg.FunnelEnabled)
 	if err != nil {
 		return nil, tserrors.WrapResource(err, "creating listener")
 	}

--- a/internal/tailscale/oauth.go
+++ b/internal/tailscale/oauth.go
@@ -116,7 +116,7 @@ func generateAuthKeyWithOAuth(oauthConfig *oauth2.Config, apiBaseURL string, tag
 }
 
 // generateOrResolveAuthKey generates an auth key using OAuth if configured, otherwise uses the resolved auth key
-func generateOrResolveAuthKey(cfg config.Config) (string, error) {
+func generateOrResolveAuthKey(cfg config.Config, svc config.Service) (string, error) {
 	// Config package has already resolved all secrets, so we can use them directly
 	clientID := cfg.Tailscale.OAuthClientID
 	clientSecret := cfg.Tailscale.OAuthClientSecret
@@ -139,7 +139,7 @@ func generateOrResolveAuthKey(cfg config.Config) (string, error) {
 				TokenURL: tokenURL,
 			},
 		}
-		authKey, err := generateAuthKeyWithOAuth(oauthConfig, apiBase, cfg.Tailscale.OAuthTags, false)
+		authKey, err := generateAuthKeyWithOAuth(oauthConfig, apiBase, svc.Tags, svc.Ephemeral)
 		if err != nil {
 			// Error from generateAuthKeyWithOAuth is already typed
 			return "", err

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -35,7 +35,6 @@ func TestNewServer(t *testing.T) {
 			cfg: config.Tailscale{
 				OAuthClientID:     "test-client-id",
 				OAuthClientSecret: "test-client-secret",
-				OAuthTags:         []string{"tag:tsbridge"},
 			},
 			wantErr: false,
 		},
@@ -139,7 +138,9 @@ func TestServer_Listen(t *testing.T) {
 	}
 
 	// Test that we can create a listener
-	listener, err := server.Listen("test-service", "auto", false)
+	svc := config.Service{Name: "test-service"}
+
+	listener, err := server.Listen(svc, "auto", false)
 	if err != nil {
 		t.Errorf("Listen() error = %v", err)
 	}
@@ -177,7 +178,9 @@ func TestServer_ListenWithFunnel(t *testing.T) {
 	}
 
 	// Test with funnel enabled
-	listener, err := server.Listen("test-service", "auto", true)
+	svc := config.Service{Name: "test-service"}
+
+	listener, err := server.Listen(svc, "auto", true)
 	if err != nil {
 		t.Errorf("Listen() with funnel error = %v", err)
 	}
@@ -328,7 +331,9 @@ func TestServerWithDependencyInjection(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		listener, err := server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		listener, err := server.Listen(svc, "auto", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -372,7 +377,9 @@ func TestServerWithDependencyInjection(t *testing.T) {
 		// Create multiple services
 		services := []string{"service1", "service2", "service3"}
 		for _, svc := range services {
-			_, err := server.Listen(svc, "auto", false)
+			svcConfig := config.Service{Name: svc}
+
+			_, err := server.Listen(svcConfig, "auto", false)
 			if err != nil {
 				t.Fatalf("unexpected error creating listener for %s: %v", svc, err)
 			}
@@ -424,7 +431,9 @@ func TestServerWithDependencyInjection(t *testing.T) {
 
 		// Create multiple services
 		for i := 0; i < 4; i++ {
-			_, err := server.Listen(string(rune('a'+i)), "auto", false)
+			svcConfig := config.Service{Name: string(rune('a' + i))}
+
+			_, err := server.Listen(svcConfig, "auto", false)
 			if err != nil {
 				t.Fatalf("unexpected error creating listener: %v", err)
 			}
@@ -517,7 +526,7 @@ func TestServiceLifecycle(t *testing.T) {
 		// Verify that Start method does not exist on the server interface
 		// This test will fail to compile if Start() method exists
 		type noStartMethodInterface interface {
-			Listen(serviceName string, tlsMode string, funnelEnabled bool) (net.Listener, error)
+			Listen(svc config.Service, tlsMode string, funnelEnabled bool) (net.Listener, error)
 			Close() error
 			GetServiceServer(serviceName string) tsnet.TSNetServer
 		}
@@ -563,7 +572,9 @@ func TestServiceLifecycle(t *testing.T) {
 		}
 
 		// Call Listen to initialize the service
-		listener, err := server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		listener, err := server.Listen(svc, "auto", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -617,7 +628,9 @@ func TestServiceLifecycle(t *testing.T) {
 		for i := 0; i < numGoroutines; i++ {
 			go func(idx int) {
 				serviceName := fmt.Sprintf("service-%d", idx)
-				listener, err := server.Listen(serviceName, "auto", false)
+				svcConfig := config.Service{Name: serviceName}
+
+				listener, err := server.Listen(svcConfig, "auto", false)
 				if err != nil {
 					errChan <- err
 				} else {
@@ -667,7 +680,9 @@ func TestServiceLifecycle(t *testing.T) {
 		}
 
 		// Listen should fail when Start fails
-		_, err = server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "auto", false)
 		if err == nil {
 			t.Error("expected error when Start fails, got nil")
 		}
@@ -704,7 +719,9 @@ func TestServiceLifecycle(t *testing.T) {
 		// Create multiple services
 		serviceNames := []string{"service1", "service2", "service3"}
 		for _, name := range serviceNames {
-			_, err := server.Listen(name, "auto", false)
+			svcConfig := config.Service{Name: name}
+
+			_, err := server.Listen(svcConfig, "auto", false)
 			if err != nil {
 				t.Fatalf("unexpected error creating listener for %s: %v", name, err)
 			}
@@ -751,7 +768,9 @@ func TestServiceLifecycle(t *testing.T) {
 		}
 
 		// Create a service
-		_, err = server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "auto", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -801,7 +820,9 @@ func TestServiceLifecycle(t *testing.T) {
 		}
 
 		// Create a service to trigger configuration
-		_, err = server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "auto", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -841,7 +862,9 @@ func TestServiceLifecycle(t *testing.T) {
 		}
 
 		// Create a service to trigger configuration
-		_, err = server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "auto", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -888,7 +911,9 @@ func TestServiceLifecycle(t *testing.T) {
 		// Create multiple services
 		services := []string{"service1", "service2", "service3"}
 		for _, svc := range services {
-			_, err := server.Listen(svc, "auto", false)
+			svcConfig := config.Service{Name: svc}
+
+			_, err := server.Listen(svcConfig, "auto", false)
 			if err != nil {
 				t.Fatalf("unexpected error creating listener for %s: %v", svc, err)
 			}
@@ -948,7 +973,7 @@ func TestEphemeralServices(t *testing.T) {
 		}
 
 		// Listen should create the server with ephemeral flag
-		_, err = server.ListenWithService(svc, "off", false)
+		_, err = server.Listen(svc, "off", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -997,7 +1022,7 @@ func TestEphemeralServices(t *testing.T) {
 		}
 
 		// Listen should create the server with ephemeral flag false
-		_, err = server.ListenWithService(svc, "off", false)
+		_, err = server.Listen(svc, "off", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1077,7 +1102,9 @@ func TestTLSMode(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		listener, err := server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		listener, err := server.Listen(svc, "auto", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1119,7 +1146,9 @@ func TestTLSMode(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		listener, err := server.Listen("test-service", "off", false)
+		svc := config.Service{Name: "test-service"}
+
+		listener, err := server.Listen(svc, "off", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1148,7 +1177,9 @@ func TestTLSMode(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		_, err = server.Listen("test-service", "invalid", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "invalid", false)
 		if err == nil {
 			t.Error("expected error for invalid TLS mode")
 		}
@@ -1214,7 +1245,9 @@ func TestTailscaleErrorTypes(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		_, err = server.Listen("test-service", "invalid-mode", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "invalid-mode", false)
 		if err == nil {
 			t.Fatal("expected error for invalid TLS mode")
 		}
@@ -1242,7 +1275,9 @@ func TestTailscaleErrorTypes(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		_, err = server.Listen("test-service", "auto", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "auto", false)
 		if err == nil {
 			t.Fatal("expected error when tsnet server fails to start")
 		}
@@ -1278,7 +1313,9 @@ func TestTailscaleErrorTypes(t *testing.T) {
 		}
 
 		// Create a service
-		_, err = server.Listen("test-service", "off", false)
+		svc := config.Service{Name: "test-service"}
+
+		_, err = server.Listen(svc, "off", false)
 		if err != nil {
 			t.Fatalf("unexpected error creating listener: %v", err)
 		}
@@ -1324,7 +1361,6 @@ func TestSecretResolutionByConfig(t *testing.T) {
 			cfg: config.Tailscale{
 				OAuthClientID:     "test-client-id",
 				OAuthClientSecret: "test-client-secret",
-				OAuthTags:         []string{"tag:test"},
 			},
 			expectNewErr: false,
 		},
@@ -1564,8 +1600,8 @@ func TestCertificatePriming(t *testing.T) {
 				BackendAddr: "localhost:8080",
 			}
 
-			// Call ListenWithService
-			listener, err := server.ListenWithService(svc, tt.tlsMode, tt.funnelEnabled)
+			// Call Listen
+			listener, err := server.Listen(svc, tt.tlsMode, tt.funnelEnabled)
 			assert.NoError(t, err)
 			assert.NotNil(t, listener)
 

--- a/test/integration/helpers/helpers.go
+++ b/test/integration/helpers/helpers.go
@@ -327,17 +327,19 @@ auth_key = "%s"`, cfg.Tailscale.AuthKey)
 oauth_client_id = "%s"
 oauth_client_secret = "%s"`, cfg.Tailscale.OAuthClientID, cfg.Tailscale.OAuthClientSecret)
 
-		if len(cfg.Tailscale.OAuthTags) > 0 {
-			content += `
-oauth_tags = [`
-			for i, tag := range cfg.Tailscale.OAuthTags {
-				if i > 0 {
-					content += ", "
-				}
-				content += fmt.Sprintf(`"%s"`, tag)
+	}
+
+	// Add default_tags if present
+	if len(cfg.Tailscale.DefaultTags) > 0 {
+		content += `
+default_tags = [`
+		for i, tag := range cfg.Tailscale.DefaultTags {
+			if i > 0 {
+				content += ", "
 			}
-			content += "]"
+			content += fmt.Sprintf(`"%s"`, tag)
 		}
+		content += `]`
 	}
 
 	content += fmt.Sprintf(`
@@ -347,14 +349,16 @@ metrics_addr = "%s"
 read_header_timeout = "%s"
 write_timeout = "%s" 
 idle_timeout = "%s"
-shutdown_timeout = "%s"
-
-`,
+shutdown_timeout = "%s"`,
 		cfg.Global.MetricsAddr,
 		cfg.Global.ReadHeaderTimeout.Duration,
 		cfg.Global.WriteTimeout.Duration,
 		cfg.Global.IdleTimeout.Duration,
 		cfg.Global.ShutdownTimeout.Duration)
+
+	content += `
+
+`
 
 	// Add services
 	for _, svc := range cfg.Services {
@@ -374,6 +378,19 @@ whois_enabled = %s
 		if svc.WhoisTimeout.Duration > 0 {
 			content += fmt.Sprintf(`whois_timeout = "%s"
 `, svc.WhoisTimeout.Duration)
+		}
+
+		// Add tags if present
+		if len(svc.Tags) > 0 {
+			content += `tags = [`
+			for i, tag := range svc.Tags {
+				if i > 0 {
+					content += ", "
+				}
+				content += fmt.Sprintf(`"%s"`, tag)
+			}
+			content += `]
+`
 		}
 	}
 


### PR DESCRIPTION
- Move OAuth tags from global to per-service configuration
- Rename oauth_tags to default_tags for clarity
- Simplify Listen API by removing duplicate method
- Add service-specific tag support for better ACL control
- Fix shared slice mutation bug in config normalization
- Simplify OAuth validation logic for better readability
- Update String() methods to include tag information
- Update all tests and documentation

This allows each service to have its own tags when using OAuth authentication, providing more granular control over Tailscale ACLs.

This closes #23.