### PR TITLE
test: fix goroutine leaks and improve test reliability

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -910,6 +910,7 @@ func TestAppMetricsAddr(t *testing.T) {
 				select {
 				case <-done:
 				case <-time.After(100 * time.Millisecond):
+					require.Fail(t, "Timeout waiting for app.Start to complete")
 				}
 
 				return app

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -139,23 +140,20 @@ func TestNewApp(t *testing.T) {
 					TSServer: tsServer,
 				})
 
-				if (err != nil) != tt.wantErr {
-					t.Errorf("NewAppWithOptions() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-
-				if !tt.wantErr && app == nil {
-					t.Error("NewAppWithOptions() returned nil app without error")
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.NotNil(t, app)
 				}
 			} else {
 				// For nil config or expected errors, use NewApp directly
 				app, err := NewApp(tt.cfg)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("NewApp() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				if !tt.wantErr && app == nil {
-					t.Error("NewApp() returned nil app without error")
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.NotNil(t, app)
 				}
 			}
 		})
@@ -219,10 +217,10 @@ func TestNewAppWithOptions(t *testing.T) {
 			app, err := NewAppWithOptions(tt.cfg, tt.opts)
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, app)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				require.NotNil(t, app)
 
 				if tt.checkFn != nil {
@@ -236,13 +234,8 @@ func TestNewAppWithOptions(t *testing.T) {
 func TestAppErrorTypes(t *testing.T) {
 	t.Run("nil config returns validation error", func(t *testing.T) {
 		_, err := NewApp(nil)
-		if err == nil {
-			t.Fatal("expected error for nil config")
-		}
-
-		if !errors.IsValidation(err) {
-			t.Errorf("expected validation error, got %v", err)
-		}
+		require.Error(t, err)
+		assert.True(t, errors.IsValidation(err), "expected validation error, got %v", err)
 	})
 
 	t.Run("invalid config returns validation error", func(t *testing.T) {
@@ -254,13 +247,8 @@ func TestAppErrorTypes(t *testing.T) {
 		}
 
 		_, err := NewApp(cfg)
-		if err == nil {
-			t.Fatal("expected error for invalid config")
-		}
-
-		if !errors.IsValidation(err) {
-			t.Errorf("expected validation error, got %v", err)
-		}
+		require.Error(t, err)
+		assert.True(t, errors.IsValidation(err), "expected validation error, got %v", err)
 	})
 }
 
@@ -356,12 +344,12 @@ func TestAppStart(t *testing.T) {
 
 			// Check expectations
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.expectedErrMessage != "" {
 					assert.Contains(t, err.Error(), tt.expectedErrMessage)
 				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -403,9 +391,9 @@ func TestAppStartIdempotency(t *testing.T) {
 	err3 := app.Start(ctx)
 
 	// All should return nil (idempotent)
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.NoError(t, err3)
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	require.NoError(t, err3)
 }
 
 // Test that Start returns without error when context is cancelled
@@ -434,9 +422,9 @@ func TestAppStartReturnsCleanlyOnContextCancel(t *testing.T) {
 	// Start should return nil (no error) when context is cancelled
 	select {
 	case err := <-startErr:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("Start did not return within timeout")
+		require.Fail(t, "Start did not return within timeout")
 	}
 }
 
@@ -471,16 +459,14 @@ func TestAppStartDoesNotBlockShutdown(t *testing.T) {
 	shutdownErr := app.Shutdown(shutdownCtx)
 
 	// Shutdown should succeed
-	assert.NoError(t, shutdownErr)
+	require.NoError(t, shutdownErr)
 }
 
 func TestAppStartWithPartialServiceFailures(t *testing.T) {
 	t.Run("app continues when some services fail", func(t *testing.T) {
 		// Start a test backend server
 		backend, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer backend.Close()
 
 		// Accept connections in background
@@ -517,17 +503,13 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Create app with the mocked dependencies
 		app, err := NewAppWithOptions(cfg, Options{
 			TSServer: tsServer,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Create a context that we'll cancel after services start
 		ctx, cancel := context.WithCancel(context.Background())
@@ -549,11 +531,9 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		select {
 		case err := <-startErr:
 			// Should have gotten a ServiceStartupError but app continued
-			if err != nil {
-				t.Errorf("expected no error from Start after graceful shutdown, got %v", err)
-			}
+			assert.NoError(t, err, "expected no error from Start after graceful shutdown")
 		case <-time.After(2 * time.Second):
-			t.Error("app did not shut down in time")
+			assert.Fail(t, "app did not shut down in time")
 		}
 	})
 
@@ -580,17 +560,13 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Create app with the mocked dependencies
 		app, err := NewAppWithOptions(cfg, Options{
 			TSServer: tsServer,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Create a context with timeout
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -601,16 +577,14 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 
 		// Should succeed because we use lazy connections
 		if err != nil {
-			t.Fatalf("expected app to start successfully with lazy connections, got error: %v", err)
+			require.NoError(t, err, "expected app to start successfully with lazy connections")
 		}
 	})
 
 	t.Run("metrics server continues when some services fail", func(t *testing.T) {
 		// Start a test backend server
 		backend, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer backend.Close()
 
 		// Accept connections in background
@@ -647,16 +621,12 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		app, err := NewAppWithOptions(cfg, Options{
 			TSServer: tsServer,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Create a context that we'll cancel after services start
 		ctx, cancel := context.WithCancel(context.Background())
@@ -686,7 +656,7 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 				t.Errorf("expected no error from Start after graceful shutdown, got %v", err)
 			}
 		case <-time.After(2 * time.Second):
-			t.Error("app did not shut down in time")
+			assert.Fail(t, "app did not shut down in time")
 		}
 	})
 }
@@ -717,7 +687,7 @@ func TestAppShutdownCanBeCalledIndependently(t *testing.T) {
 	defer shutdownCancel()
 
 	err = app.Shutdown(shutdownCtx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Now cancel the start context
 	cancel()
@@ -725,9 +695,9 @@ func TestAppShutdownCanBeCalledIndependently(t *testing.T) {
 	// Wait for Start to return
 	select {
 	case err := <-startErr:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("Start did not return within timeout")
+		require.Fail(t, "Start did not return within timeout")
 	}
 }
 
@@ -749,7 +719,7 @@ func TestAppShutdownErrorTypes(t *testing.T) {
 
 		app, err := NewApp(cfg)
 		if err != nil {
-			t.Fatalf("failed to create app: %v", err)
+			require.NoError(t, err, "failed to create app")
 		}
 
 		// Shutdown immediately (nothing to shut down)
@@ -800,7 +770,7 @@ func TestAppPerformShutdown(t *testing.T) {
 	// Now test performShutdown
 	shutdownCtx := context.Background()
 	err = app.performShutdown(shutdownCtx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestAppSetupMetrics(t *testing.T) {
@@ -853,12 +823,12 @@ func TestAppSetupMetrics(t *testing.T) {
 
 			// Check expectations
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.expectedErrMessage != "" {
 					assert.Contains(t, err.Error(), tt.expectedErrMessage)
 				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, app.metricsServer)
 			}
 		})
@@ -929,12 +899,18 @@ func TestAppMetricsAddr(t *testing.T) {
 				require.NoError(t, err)
 
 				// Start metrics server to get actual address
-				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-				go func() { _ = app.Start(ctx) }()
 
-				// Give it a moment to start
-				time.Sleep(20 * time.Millisecond)
+				// Use a channel to ensure Start completes
+				done := make(chan error)
+				go func() { done <- app.Start(ctx) }()
+
+				// Wait for Start to complete or timeout
+				select {
+				case <-done:
+				case <-time.After(100 * time.Millisecond):
+				}
 
 				return app
 			},
@@ -986,7 +962,7 @@ func TestMetricsServerIntegration(t *testing.T) {
 
 	// Shutdown
 	err = server.Shutdown(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestAppPartialFailureLogging verifies that partial failures are logged correctly
@@ -994,4 +970,367 @@ func TestAppPartialFailureLogging(t *testing.T) {
 	// This test would capture logs to verify proper error reporting
 	// For now, we're focusing on the behavior rather than log output
 	t.Skip("Log capture test not implemented")
+}
+
+func TestWatchConfigChanges(t *testing.T) {
+	t.Run("handles config updates", func(t *testing.T) {
+		// Create initial config
+		cfg := &config.Config{
+			Tailscale: config.Tailscale{
+				StateDir:          t.TempDir(),
+				OAuthClientID:     "test-client-id",
+				OAuthClientSecret: "test-client-secret",
+			},
+			Services: []config.Service{
+				{
+					Name:        "test-service",
+					BackendAddr: "localhost:8080",
+					Tags:        []string{"tag:test"},
+				},
+			},
+		}
+		cfg.SetDefaults()
+
+		// Create app
+		tsServer := createMockTailscaleServer(t, cfg.Tailscale)
+		app, err := NewAppWithOptions(cfg, Options{TSServer: tsServer})
+		require.NoError(t, err)
+
+		// Create config channel
+		configCh := make(chan *config.Config, 1)
+
+		// Start watching in background
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go app.watchConfigChanges(ctx, configCh)
+
+		// Send new config
+		newCfg := &config.Config{
+			Tailscale: cfg.Tailscale,
+			Services: []config.Service{
+				{
+					Name:        "test-service",
+					BackendAddr: "localhost:8081", // Changed port
+					Tags:        []string{"tag:test"},
+				},
+				{
+					Name:        "new-service",
+					BackendAddr: "localhost:8082",
+					Tags:        []string{"tag:test"},
+				},
+			},
+		}
+		newCfg.SetDefaults()
+
+		configCh <- newCfg
+
+		// Give it time to process
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify config was updated
+		app.mu.RLock()
+		assert.Equal(t, 2, len(app.cfg.Services))
+		assert.Equal(t, "localhost:8081", app.cfg.Services[0].BackendAddr)
+		assert.Equal(t, "new-service", app.cfg.Services[1].Name)
+		app.mu.RUnlock()
+	})
+
+	t.Run("stops watching when context is cancelled", func(t *testing.T) {
+		// Create config
+		cfg := &config.Config{
+			Tailscale: config.Tailscale{
+				StateDir:          t.TempDir(),
+				OAuthClientID:     "test-client-id",
+				OAuthClientSecret: "test-client-secret",
+			},
+			Services: []config.Service{
+				{
+					Name:        "test-service",
+					BackendAddr: "localhost:8080",
+					Tags:        []string{"tag:test"},
+				},
+			},
+		}
+		cfg.SetDefaults()
+
+		// Create app
+		tsServer := createMockTailscaleServer(t, cfg.Tailscale)
+		app, err := NewAppWithOptions(cfg, Options{TSServer: tsServer})
+		require.NoError(t, err)
+
+		// Create config channel
+		configCh := make(chan *config.Config, 1)
+
+		// Start watching
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			app.watchConfigChanges(ctx, configCh)
+			close(done)
+		}()
+
+		// Cancel context
+		cancel()
+
+		// Verify goroutine exits
+		select {
+		case <-done:
+			// Good, goroutine exited
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "watchConfigChanges did not exit when context was cancelled")
+		}
+	})
+
+	t.Run("stops watching when channel is closed", func(t *testing.T) {
+		// Create config
+		cfg := &config.Config{
+			Tailscale: config.Tailscale{
+				StateDir:          t.TempDir(),
+				OAuthClientID:     "test-client-id",
+				OAuthClientSecret: "test-client-secret",
+			},
+			Services: []config.Service{
+				{
+					Name:        "test-service",
+					BackendAddr: "localhost:8080",
+					Tags:        []string{"tag:test"},
+				},
+			},
+		}
+		cfg.SetDefaults()
+
+		// Create app
+		tsServer := createMockTailscaleServer(t, cfg.Tailscale)
+		app, err := NewAppWithOptions(cfg, Options{TSServer: tsServer})
+		require.NoError(t, err)
+
+		// Create config channel
+		configCh := make(chan *config.Config)
+
+		// Start watching
+		ctx := context.Background()
+		done := make(chan struct{})
+		go func() {
+			app.watchConfigChanges(ctx, configCh)
+			close(done)
+		}()
+
+		// Close channel
+		close(configCh)
+
+		// Verify goroutine exits
+		select {
+		case <-done:
+			// Good, goroutine exited
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "watchConfigChanges did not exit when channel was closed")
+		}
+	})
+}
+
+func TestReloadConfig(t *testing.T) {
+	t.Run("updates config successfully", func(t *testing.T) {
+		// Create initial config
+		cfg := &config.Config{
+			Tailscale: config.Tailscale{
+				StateDir:          t.TempDir(),
+				OAuthClientID:     "test-client-id",
+				OAuthClientSecret: "test-client-secret",
+			},
+			Services: []config.Service{
+				{
+					Name:        "test-service",
+					BackendAddr: "localhost:8080",
+					Tags:        []string{"tag:test"},
+				},
+			},
+		}
+		cfg.SetDefaults()
+
+		// Create app
+		tsServer := createMockTailscaleServer(t, cfg.Tailscale)
+		app, err := NewAppWithOptions(cfg, Options{TSServer: tsServer})
+		require.NoError(t, err)
+
+		// Create new config
+		newCfg := &config.Config{
+			Tailscale: cfg.Tailscale,
+			Services: []config.Service{
+				{
+					Name:        "test-service",
+					BackendAddr: "localhost:8081",
+					Tags:        []string{"tag:test"},
+				},
+				{
+					Name:        "new-service",
+					BackendAddr: "localhost:8082",
+					Tags:        []string{"tag:test"},
+				},
+			},
+		}
+		newCfg.SetDefaults()
+
+		// Reload config
+		err = app.reloadConfig(newCfg)
+		require.NoError(t, err)
+
+		// Verify config was updated
+		assert.Equal(t, 2, len(app.cfg.Services))
+		assert.Equal(t, "localhost:8081", app.cfg.Services[0].BackendAddr)
+		assert.Equal(t, "new-service", app.cfg.Services[1].Name)
+	})
+
+	t.Run("handles concurrent reloads", func(t *testing.T) {
+		// Create initial config
+		cfg := &config.Config{
+			Tailscale: config.Tailscale{
+				StateDir:          t.TempDir(),
+				OAuthClientID:     "test-client-id",
+				OAuthClientSecret: "test-client-secret",
+			},
+			Services: []config.Service{
+				{
+					Name:        "test-service",
+					BackendAddr: "localhost:8080",
+					Tags:        []string{"tag:test"},
+				},
+			},
+		}
+		cfg.SetDefaults()
+
+		// Create app
+		tsServer := createMockTailscaleServer(t, cfg.Tailscale)
+		app, err := NewAppWithOptions(cfg, Options{TSServer: tsServer})
+		require.NoError(t, err)
+
+		// Run multiple concurrent reloads
+		done := make(chan bool)
+		for i := 0; i < 10; i++ {
+			go func(port int) {
+				newCfg := &config.Config{
+					Tailscale: cfg.Tailscale,
+					Services: []config.Service{
+						{
+							Name:        "test-service",
+							BackendAddr: fmt.Sprintf("localhost:%d", 8080+port),
+							Tags:        []string{"tag:test"},
+						},
+					},
+				}
+				newCfg.SetDefaults()
+				app.reloadConfig(newCfg)
+				done <- true
+			}(i)
+		}
+
+		// Wait for all goroutines
+		for i := 0; i < 10; i++ {
+			<-done
+		}
+
+		// Verify final state is consistent
+		assert.Equal(t, 1, len(app.cfg.Services))
+		assert.Equal(t, "test-service", app.cfg.Services[0].Name)
+	})
+}
+
+func TestConfigWatchIntegration(t *testing.T) {
+	t.Run("provider with config watching", func(t *testing.T) {
+		// Create a mock provider that supports watching
+		mockProvider := &mockConfigProvider{
+			name: "mock",
+			loadFunc: func(ctx context.Context) (*config.Config, error) {
+				cfg := &config.Config{
+					Tailscale: config.Tailscale{
+						StateDir: t.TempDir(),
+						AuthKey:  "test-auth-key",
+					},
+					Services: []config.Service{
+						{
+							Name:        "test-service",
+							BackendAddr: "localhost:8080",
+						},
+					},
+				}
+				cfg.SetDefaults()
+				return cfg, nil
+			},
+			watchFunc: func(ctx context.Context) (<-chan *config.Config, error) {
+				ch := make(chan *config.Config, 1)
+				go func() {
+					// Simulate a config change after a short delay
+					time.Sleep(100 * time.Millisecond)
+					cfg := &config.Config{
+						Tailscale: config.Tailscale{
+							StateDir: t.TempDir(),
+							AuthKey:  "test-auth-key",
+						},
+						Services: []config.Service{
+							{
+								Name:        "test-service",
+								BackendAddr: "localhost:8081", // Changed
+							},
+						},
+					}
+					cfg.SetDefaults()
+					select {
+					case ch <- cfg:
+					case <-ctx.Done():
+					}
+				}()
+				return ch, nil
+			},
+		}
+
+		// Create app with the provider and mock tsnet server
+		tsServer := createMockTailscaleServer(t, config.Tailscale{AuthKey: "test-auth-key"})
+		app, err := NewAppWithOptions(nil, Options{Provider: mockProvider, TSServer: tsServer})
+		require.NoError(t, err)
+
+		// Start the app
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err = app.Start(ctx)
+		require.NoError(t, err)
+
+		// Wait for config change to be processed
+		time.Sleep(200 * time.Millisecond)
+
+		// Verify config was updated
+		app.mu.RLock()
+		assert.Equal(t, "localhost:8081", app.cfg.Services[0].BackendAddr)
+		app.mu.RUnlock()
+
+		// Shutdown
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		err = app.Shutdown(shutdownCtx)
+		require.NoError(t, err)
+	})
+}
+
+// mockConfigProvider implements config.Provider for testing
+type mockConfigProvider struct {
+	name      string
+	loadFunc  func(ctx context.Context) (*config.Config, error)
+	watchFunc func(ctx context.Context) (<-chan *config.Config, error)
+}
+
+func (m *mockConfigProvider) Name() string {
+	return m.name
+}
+
+func (m *mockConfigProvider) Load(ctx context.Context) (*config.Config, error) {
+	if m.loadFunc != nil {
+		return m.loadFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockConfigProvider) Watch(ctx context.Context) (<-chan *config.Config, error) {
+	if m.watchFunc != nil {
+		return m.watchFunc(ctx)
+	}
+	return nil, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -459,9 +459,7 @@ func TestResolveSecrets(t *testing.T) {
 		}
 
 		err := resolveSecrets(cfg)
-		if err != nil {
-			t.Fatalf("resolveSecrets() error = %v", err)
-		}
+		require.NoError(t, err, "resolveSecrets() failed")
 
 		if cfg.Tailscale.OAuthClientID != "test-id" {
 			t.Errorf("OAuthClientID = %v, want %v", cfg.Tailscale.OAuthClientID, "test-id")
@@ -481,9 +479,7 @@ func TestResolveSecrets(t *testing.T) {
 		}
 
 		err := resolveSecrets(cfg)
-		if err != nil {
-			t.Fatalf("resolveSecrets() error = %v", err)
-		}
+		require.NoError(t, err, "resolveSecrets() failed")
 
 		if cfg.Tailscale.OAuthClientSecret != "test-secret" {
 			t.Errorf("OAuthClientSecret = %v, want %v", cfg.Tailscale.OAuthClientSecret, "test-secret")
@@ -497,9 +493,7 @@ func TestResolveSecrets(t *testing.T) {
 		}
 
 		err := resolveSecrets(cfg)
-		if err != nil {
-			t.Fatalf("resolveSecrets() error = %v", err)
-		}
+		require.NoError(t, err, "resolveSecrets() failed")
 
 		if cfg.Tailscale.AuthKey != "fallback-key" {
 			t.Errorf("AuthKey = %v, want %v", cfg.Tailscale.AuthKey, "fallback-key")
@@ -516,9 +510,7 @@ func TestResolveSecrets(t *testing.T) {
 		}
 
 		err := resolveSecrets(cfg)
-		if err != nil {
-			t.Fatalf("resolveSecrets() error = %v", err)
-		}
+		require.NoError(t, err, "resolveSecrets() failed")
 
 		if cfg.Tailscale.OAuthClientID != "env-id" {
 			t.Errorf("OAuthClientID = %v, want %v", cfg.Tailscale.OAuthClientID, "env-id")

--- a/internal/middleware/accesslog_test.go
+++ b/internal/middleware/accesslog_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -207,7 +208,7 @@ func TestAccessLogWebSocketSupport(t *testing.T) {
 			assert.True(t, ok, "ResponseWriter should implement http.Hijacker for WebSocket support")
 
 			conn, bufrw, err := hijacker.Hijack()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer conn.Close()
 
 			// Write WebSocket upgrade response
@@ -240,7 +241,7 @@ func TestAccessLogWebSocketSupport(t *testing.T) {
 
 		// Create WebSocket upgrade request
 		req, err := http.NewRequest("GET", server.URL, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		req.Header.Set("Upgrade", "websocket")
 		req.Header.Set("Connection", "Upgrade")
 		req.Header.Set("Sec-WebSocket-Version", "13")
@@ -249,7 +250,7 @@ func TestAccessLogWebSocketSupport(t *testing.T) {
 		// Make the request
 		client := &http.Client{}
 		resp, err := client.Do(req)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 
 		// Should get 101 Switching Protocols

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -60,10 +60,6 @@ func (m *MockWhoisAdapter) WhoIs(ctx context.Context, remoteAddr string) (*apity
 	return nil, nil
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && s[:len(substr)] == substr || len(s) > len(substr) && contains(s[1:], substr)
-}
-
 func TestRegistry_StartServices(t *testing.T) {
 	// Start a mock backend server
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -189,9 +189,7 @@ func TestRegistry_StartServices_WithBackendHealthCheck(t *testing.T) {
 
 			// Create tsnet server using the test factory
 			tsServer, err := testTailscaleServerFactory()
-			if err != nil {
-				t.Fatalf("failed to create tailscale server: %v", err)
-			}
+			require.NoError(t, err, "failed to create tailscale server")
 
 			// Create registry
 			registry := NewRegistry(cfg, tsServer)
@@ -199,16 +197,13 @@ func TestRegistry_StartServices_WithBackendHealthCheck(t *testing.T) {
 			// Start services
 			err = registry.StartServices()
 
-			if tt.expectError && err == nil {
-				t.Error("expected error, got nil")
-			}
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
+			if tt.expectError {
+				require.Error(t, err, "expected error, got nil")
+			} else {
+				assert.NoError(t, err, "unexpected error")
 			}
 
-			if len(registry.services) != tt.expectedServices {
-				t.Errorf("expected %d services, got %d", tt.expectedServices, len(registry.services))
-			}
+			assert.Len(t, registry.services, tt.expectedServices)
 		})
 	}
 }
@@ -225,14 +220,10 @@ func TestServiceRegistryErrorTypes(t *testing.T) {
 		registry := NewRegistry(cfg, nil)
 
 		err := registry.StartServices()
-		if err == nil {
-			t.Fatal("expected error when no services configured")
-		}
+		require.Error(t, err, "expected error when no services configured")
 
 		// Should be an internal error
-		if !errors.IsInternal(err) {
-			t.Errorf("expected internal error, got %v", err)
-		}
+		assert.True(t, errors.IsInternal(err), "expected internal error, got %v", err)
 	})
 }
 
@@ -267,36 +258,25 @@ func TestServiceStartupPartialFailures(t *testing.T) {
 			AuthKey: "test-key",
 		}
 		tsServer, err := tailscale.NewServerWithFactory(tsServerCfg, failService1Factory)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer tsServer.Close()
 
 		registry := NewRegistry(cfg, tsServer)
 
 		err = registry.StartServices()
-		if err == nil {
-			t.Fatal("expected error when listener creation fails")
-		}
+		require.Error(t, err, "expected error when listener creation fails")
 
 		// Should be a ServiceStartupError
 		startupErr, ok := errors.AsServiceStartupError(err)
-		if !ok {
-			t.Errorf("expected ServiceStartupError, got %v", err)
-		}
+		assert.True(t, ok, "expected ServiceStartupError, got %v", err)
 
 		// Should have 1 failure (service1) and 1 success (service2)
-		if startupErr.Failed != 1 {
-			t.Errorf("expected 1 failed service, got %d", startupErr.Failed)
-		}
-		if startupErr.Successful != 1 {
-			t.Errorf("expected 1 successful service, got %d", startupErr.Successful)
-		}
+		assert.Equal(t, 1, startupErr.Failed, "expected 1 failed service")
+		assert.Equal(t, 1, startupErr.Successful, "expected 1 successful service")
 
 		// Error should mention listener creation
-		if _, ok := startupErr.Failures["service1"]; !ok {
-			t.Error("expected failure for service1")
-		}
+		_, ok = startupErr.Failures["service1"]
+		assert.True(t, ok, "expected failure for service1")
 	})
 }
 
@@ -311,17 +291,13 @@ func TestService_Handler(t *testing.T) {
 
 	// Initialize the handler
 	handler, err := svc.CreateHandler()
-	if err != nil {
-		t.Fatalf("failed to create handler: %v", err)
-	}
+	require.NoError(t, err, "failed to create handler")
 	svc.handler = handler
 
 	handler = svc.Handler()
 
 	// Just verify we get a handler
-	if handler == nil {
-		t.Error("expected handler, got nil")
-	}
+	assert.NotNil(t, handler, "expected handler, got nil")
 }
 
 func TestService_HandlerWithResponseHeaderTimeout(t *testing.T) {
@@ -375,17 +351,13 @@ func TestService_HandlerWithResponseHeaderTimeout(t *testing.T) {
 
 			// Initialize the handler
 			handler, err := svc.CreateHandler()
-			if err != nil {
-				t.Fatalf("failed to create handler: %v", err)
-			}
+			require.NoError(t, err, "failed to create handler")
 			svc.handler = handler
 
 			// We can't directly test the timeout value in the handler,
 			// but we can verify the handler is created successfully
 			handler = svc.Handler()
-			if handler == nil {
-				t.Error("expected handler, got nil")
-			}
+			assert.NotNil(t, handler, "expected handler, got nil")
 		})
 	}
 }
@@ -394,9 +366,7 @@ func TestService_HandlerWithMetrics(t *testing.T) {
 	collector := metrics.NewCollector()
 	reg := prometheus.NewRegistry()
 	err := collector.Register(reg)
-	if err != nil {
-		t.Fatalf("failed to register metrics: %v", err)
-	}
+	require.NoError(t, err, "failed to register metrics")
 
 	// Test that the service handler integrates metrics middleware
 	svc := &Service{
@@ -409,17 +379,13 @@ func TestService_HandlerWithMetrics(t *testing.T) {
 
 	// Initialize the handler
 	handler, err := svc.CreateHandler()
-	if err != nil {
-		t.Fatalf("failed to create handler: %v", err)
-	}
+	require.NoError(t, err, "failed to create handler")
 	svc.handler = handler
 
 	handler = svc.Handler()
 
 	// Just verify we get a handler
-	if handler == nil {
-		t.Error("expected handler, got nil")
-	}
+	assert.NotNil(t, handler, "expected handler, got nil")
 }
 
 func TestService_isAccessLogEnabled(t *testing.T) {
@@ -565,9 +531,7 @@ func TestServiceWithWhoisMiddleware(t *testing.T) {
 
 			// Initialize the handler
 			handler, err := svc.CreateHandler()
-			if err != nil {
-				t.Fatalf("failed to create handler: %v", err)
-			}
+			require.NoError(t, err, "failed to create handler")
 			svc.handler = handler
 
 			// Create the handler manually to simulate what would happen
@@ -588,24 +552,19 @@ func TestServiceWithWhoisMiddleware(t *testing.T) {
 			handler.ServeHTTP(w, req)
 
 			// Check status
-			if w.Code != http.StatusOK {
-				t.Errorf("got status %d, want %d", w.Code, http.StatusOK)
-			}
+			assert.Equal(t, http.StatusOK, w.Code)
 
 			// Check headers
 			for header, want := range tt.wantHeaders {
 				got := w.Header().Get(header)
-				if got != want {
-					t.Errorf("header %s = %q, want %q", header, got, want)
-				}
+				assert.Equal(t, want, got, "header %s", header)
 			}
 
 			// Check that no headers are present when whois is disabled
 			if !tt.whoisEnabled {
 				for _, header := range []string{"Echo-X-Tailscale-User", "Echo-X-Tailscale-Name", "Echo-X-Tailscale-Login"} {
-					if got := w.Header().Get(header); got != "" {
-						t.Errorf("header %s = %q, want empty (whois disabled)", header, got)
-					}
+					got := w.Header().Get(header)
+					assert.Empty(t, got, "header %s should be empty (whois disabled)", header)
 				}
 			}
 		})
@@ -616,9 +575,7 @@ func TestRegistry_Shutdown(t *testing.T) {
 
 	// Start a mock backend server
 	backend, err := net.Listen("tcp", "localhost:8081")
-	if err != nil {
-		t.Fatalf("failed to create backend listener: %v", err)
-	}
+	require.NoError(t, err, "failed to create backend listener")
 	defer func() {
 		if err := backend.Close(); err != nil {
 			t.Logf("failed to close backend: %v", err)
@@ -660,25 +617,19 @@ func TestRegistry_Shutdown(t *testing.T) {
 
 	// Create tsnet server using the test factory
 	tsServer, err := testTailscaleServerFactory()
-	if err != nil {
-		t.Fatalf("failed to create tailscale server: %v", err)
-	}
+	require.NoError(t, err, "failed to create tailscale server")
 
 	// Create registry and start services
 	registry := NewRegistry(cfg, tsServer)
 	err = registry.StartServices()
-	if err != nil {
-		t.Fatalf("failed to start services: %v", err)
-	}
+	require.NoError(t, err, "failed to start services")
 
 	// Test graceful shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Global.ShutdownTimeout.Duration)
 	defer cancel()
 
 	err = registry.Shutdown(ctx)
-	if err != nil {
-		t.Errorf("shutdown failed: %v", err)
-	}
+	assert.NoError(t, err, "shutdown failed")
 }
 
 // TestShutdownWithInflightRequests verifies that shutdown waits for in-flight
@@ -750,9 +701,7 @@ func TestShutdownWithInflightRequests(t *testing.T) {
 
 			// Start server on a random port
 			listener, err := net.Listen("tcp", "localhost:0")
-			if err != nil {
-				t.Fatalf("failed to create listener: %v", err)
-			}
+			require.NoError(t, err, "failed to create listener")
 			defer func() {
 				if err := listener.Close(); err != nil {
 					t.Logf("failed to close listener: %v", err)
@@ -792,9 +741,7 @@ func TestShutdownWithInflightRequests(t *testing.T) {
 			mu.Lock()
 			currentActive := activeRequests
 			mu.Unlock()
-			if currentActive != 1 {
-				t.Errorf("expected 1 active request, got %d", currentActive)
-			}
+			assert.Equal(t, int32(1), currentActive, "expected 1 active request")
 
 			// Initiate shutdown
 			shutdownStart := time.Now()
@@ -808,53 +755,37 @@ func TestShutdownWithInflightRequests(t *testing.T) {
 			<-serverDone
 
 			// Check if server error is expected (ErrServerClosed)
-			if serverErr != http.ErrServerClosed {
-				t.Errorf("expected ErrServerClosed, got %v", serverErr)
-			}
+			assert.Equal(t, http.ErrServerClosed, serverErr, "expected ErrServerClosed")
 
 			// Wait for request to complete or timeout
 			select {
 			case <-requestDone:
 				// Request finished (either completed or failed)
 			case <-time.After(3 * time.Second):
-				t.Fatal("request did not finish in time")
+				require.Fail(t, "request did not finish in time")
 			}
 
 			// Verify no active requests remain
 			mu.Lock()
 			finalActive := activeRequests
 			mu.Unlock()
-			if finalActive != 0 {
-				t.Errorf("expected 0 active requests after shutdown, got %d", finalActive)
-			}
+			assert.Equal(t, int32(0), finalActive, "expected 0 active requests after shutdown")
 
 			// Check shutdown duration
 			if tt.expectRequestComplete {
 				// Shutdown should have waited for request
-				if shutdownDuration < tt.requestDuration-100*time.Millisecond {
-					t.Errorf("shutdown completed too quickly: %v < %v", shutdownDuration, tt.requestDuration)
-				}
+				assert.GreaterOrEqual(t, shutdownDuration, tt.requestDuration-100*time.Millisecond, "shutdown completed too quickly")
 				mu.Lock()
 				completed := requestCompleted
 				mu.Unlock()
-				if !completed {
-					t.Error("expected request to complete, but it didn't")
-				}
-				if shutdownErr != nil {
-					t.Errorf("expected clean shutdown, got error: %v", shutdownErr)
-				}
+				assert.True(t, completed, "expected request to complete")
+				assert.NoError(t, shutdownErr, "expected clean shutdown")
 			} else {
 				// Shutdown should have timed out
-				if shutdownDuration < tt.shutdownTimeout-100*time.Millisecond {
-					t.Errorf("shutdown completed too quickly: %v < %v", shutdownDuration, tt.shutdownTimeout)
-				}
-				if shutdownDuration > tt.shutdownTimeout+500*time.Millisecond {
-					t.Errorf("shutdown took too long: %v > %v", shutdownDuration, tt.shutdownTimeout)
-				}
+				assert.GreaterOrEqual(t, shutdownDuration, tt.shutdownTimeout-100*time.Millisecond, "shutdown completed too quickly")
+				assert.LessOrEqual(t, shutdownDuration, tt.shutdownTimeout+500*time.Millisecond, "shutdown took too long")
 				// Context deadline exceeded error is expected
-				if shutdownErr == nil || shutdownErr != context.DeadlineExceeded {
-					t.Errorf("expected context.DeadlineExceeded, got %v", shutdownErr)
-				}
+				assert.Equal(t, context.DeadlineExceeded, shutdownErr, "expected context.DeadlineExceeded")
 			}
 		})
 	}
@@ -894,9 +825,7 @@ func TestConcurrentShutdown(t *testing.T) {
 
 		// Start each service
 		listener, err := net.Listen("tcp", "localhost:0")
-		if err != nil {
-			t.Fatalf("failed to create listener for service %d: %v", i, err)
-		}
+		require.NoError(t, err, "failed to create listener for service %d", i)
 		defer func() {
 			if err := listener.Close(); err != nil {
 				t.Logf("failed to close listener: %v", err)
@@ -918,14 +847,10 @@ func TestConcurrentShutdown(t *testing.T) {
 	err := registry.Shutdown(ctx)
 	shutdownDuration := time.Since(shutdownStart)
 
-	if err != nil {
-		t.Errorf("unexpected shutdown error: %v", err)
-	}
+	assert.NoError(t, err, "unexpected shutdown error")
 
 	// Verify shutdown was concurrent (should be much less than numServices * 100ms)
-	if shutdownDuration > 500*time.Millisecond {
-		t.Errorf("shutdown took too long for concurrent operation: %v", shutdownDuration)
-	}
+	assert.LessOrEqual(t, shutdownDuration, 500*time.Millisecond, "shutdown took too long for concurrent operation")
 }
 
 // TestShutdownErrorHandling verifies that shutdown collects and returns all errors
@@ -955,9 +880,7 @@ func TestShutdownErrorHandling(t *testing.T) {
 	}
 
 	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("failed to create listener: %v", err)
-	}
+	require.NoError(t, err, "failed to create listener")
 	defer func() {
 		if err := listener.Close(); err != nil {
 			t.Logf("failed to close listener: %v", err)
@@ -983,12 +906,10 @@ func TestShutdownErrorHandling(t *testing.T) {
 	err = registry.Shutdown(ctx)
 
 	// Should get an error due to timeout
-	if err == nil {
-		t.Error("expected shutdown error due to timeout, got nil")
-	}
+	assert.Error(t, err, "expected shutdown error due to timeout")
 
-	if err != nil && !contains(err.Error(), "hanging-service") {
-		t.Errorf("error should mention the service name, got: %v", err)
+	if err != nil {
+		assert.Contains(t, err.Error(), "hanging-service", "error should mention the service name")
 	}
 }
 
@@ -1121,9 +1042,7 @@ func TestShutdownIdempotency(t *testing.T) {
 	}
 
 	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("failed to create listener: %v", err)
-	}
+	require.NoError(t, err, "failed to create listener")
 	defer func() {
 		if err := listener.Close(); err != nil {
 			t.Logf("failed to close listener: %v", err)
@@ -1137,15 +1056,11 @@ func TestShutdownIdempotency(t *testing.T) {
 	ctx1, cancel1 := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel1()
 	err1 := registry.Shutdown(ctx1)
-	if err1 != nil {
-		t.Errorf("first shutdown failed: %v", err1)
-	}
+	assert.NoError(t, err1, "first shutdown failed")
 
 	// Second shutdown (should be safe)
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel2()
 	err2 := registry.Shutdown(ctx2)
-	if err2 != nil {
-		t.Errorf("second shutdown failed: %v", err2)
-	}
+	assert.NoError(t, err2, "second shutdown failed")
 }

--- a/test/integration/shutdown_test.go
+++ b/test/integration/shutdown_test.go
@@ -81,8 +81,7 @@ func TestE2EShutdownWithActiveRequests(t *testing.T) {
 	assert.Less(t, shutdownDuration, 3*time.Second, "shutdown took too long")
 
 	// Verify shutdown happened - at least one of these messages should appear
-	if !strings.Contains(output, "shutdown complete") && !strings.Contains(output, "shutting down") {
-		t.Error("did not see shutdown messages")
-		t.Logf("Output:\n%s", output)
-	}
+	shutdownComplete := strings.Contains(output, "shutdown complete")
+	shuttingDown := strings.Contains(output, "shutting down")
+	assert.True(t, shutdownComplete || shuttingDown, "did not see shutdown messages in output:\n%s", output)
 }


### PR DESCRIPTION
- Add buffered channels to test HTTP servers to prevent goroutine leaks
- Replace regular map with sync.Map in shutdown tests for thread-safe access
- Add proper context cleanup with defer in OAuth tests
- Remove flaky TestInMemoryMetricsCollection that duplicated unit tests
- Add HTTP retry logic in metrics integration tests
- Make test assertions more tolerant of timing variations
- Remove unused testify imports in OAuth tests