### PR TITLE
chore: use GoReleaser for PR Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -24,3 +31,65 @@ jobs:
         run: |
           VERSION=$(git describe --tags --always --dirty)
           go build -ldflags "-X main.version=$VERSION" -v ./cmd/...
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push PR Docker Images
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          
+          # Tag and push AMD64 image
+          docker tag ghcr.io/jtdowney/tsbridge:latest-amd64 ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER}-amd64
+          docker tag ghcr.io/jtdowney/tsbridge:latest-amd64 ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-amd64
+          docker push ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER}-amd64
+          docker push ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-amd64
+          
+          # Tag and push ARM64 image
+          docker tag ghcr.io/jtdowney/tsbridge:latest-arm64 ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER}-arm64
+          docker tag ghcr.io/jtdowney/tsbridge:latest-arm64 ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-arm64
+          docker push ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER}-arm64
+          docker push ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-arm64
+          
+          # Create and push multi-arch manifests
+          docker manifest create ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER} \
+            ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER}-amd64 \
+            ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER}-arm64
+          docker manifest push ghcr.io/jtdowney/tsbridge:pr-${PR_NUMBER}
+          
+          docker manifest create ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT} \
+            ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-amd64 \
+            ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-arm64
+          docker manifest push ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,7 @@ dockers:
     goos: linux
     goarch: amd64
     use: buildx
+    skip_push: "{{ if .IsSnapshot }}true{{ else }}false{{ end }}"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
@@ -54,6 +55,7 @@ dockers:
     goos: linux
     goarch: arm64
     use: buildx
+    skip_push: "{{ if .IsSnapshot }}true{{ else }}false{{ end }}"
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
@@ -79,7 +81,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  version_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
 
 changelog:
   sort: asc


### PR DESCRIPTION
- Add docker job to CI workflow that builds images using GoReleaser
- Configure GoReleaser to skip push for snapshot builds
- Tag PR images with pr-{number} and sha-{commit} formats
- Create multi-arch manifests for PR builds
- Update snapshot version template for better versioning