### PR TITLE
fix: prevent HTTP header injection in whois middleware

### DIFF
--- a/internal/middleware/whois_test.go
+++ b/internal/middleware/whois_test.go
@@ -217,3 +217,185 @@ func TestWhoisCaching(t *testing.T) {
 		t.Errorf("Third request: lookupCount = %d, want 2", lookupCount)
 	}
 }
+
+func TestWhoisHeaderInjectionPrevention(t *testing.T) {
+	tests := []struct {
+		name        string
+		userProfile *tailcfg.UserProfile
+		wantHeaders map[string]string
+		description string
+	}{
+		{
+			name: "header injection with newline in LoginName",
+			userProfile: &tailcfg.UserProfile{
+				LoginName:     "user@example.com\r\nX-Injected: evil",
+				DisplayName:   "Normal User",
+				ProfilePicURL: "https://example.com/pic.jpg",
+			},
+			wantHeaders: map[string]string{
+				"X-Tailscale-User":            "user@example.comX-Injected: evil",
+				"X-Tailscale-Login":           "user@example.comX-Injected: evil",
+				"X-Tailscale-Name":            "Normal User",
+				"X-Tailscale-Profile-Picture": "https://example.com/pic.jpg",
+			},
+			description: "Newlines should be removed from LoginName",
+		},
+		{
+			name: "header injection with CRLF in DisplayName",
+			userProfile: &tailcfg.UserProfile{
+				LoginName:     "user@example.com",
+				DisplayName:   "Evil\r\nX-Malicious: true\r\nUser",
+				ProfilePicURL: "https://example.com/pic.jpg",
+			},
+			wantHeaders: map[string]string{
+				"X-Tailscale-User":            "user@example.com",
+				"X-Tailscale-Login":           "user@example.com",
+				"X-Tailscale-Name":            "EvilX-Malicious: trueUser",
+				"X-Tailscale-Profile-Picture": "https://example.com/pic.jpg",
+			},
+			description: "CRLF sequences should be removed from DisplayName",
+		},
+		{
+			name: "header injection in ProfilePicURL",
+			userProfile: &tailcfg.UserProfile{
+				LoginName:     "user@example.com",
+				DisplayName:   "Test User",
+				ProfilePicURL: "https://example.com/pic.jpg\r\nX-Hack: yes",
+			},
+			wantHeaders: map[string]string{
+				"X-Tailscale-User":            "user@example.com",
+				"X-Tailscale-Login":           "user@example.com",
+				"X-Tailscale-Name":            "Test User",
+				"X-Tailscale-Profile-Picture": "https://example.com/pic.jpgX-Hack: yes",
+			},
+			description: "Newlines should be removed from ProfilePicURL",
+		},
+		{
+			name: "multiple injection attempts",
+			userProfile: &tailcfg.UserProfile{
+				LoginName:     "bad\r\nX-Bad1: true",
+				DisplayName:   "also\nbad\r\nX-Bad2: yes",
+				ProfilePicURL: "https://evil.com\r\n\r\nX-Bad3: absolutely",
+			},
+			wantHeaders: map[string]string{
+				"X-Tailscale-User":            "badX-Bad1: true",
+				"X-Tailscale-Login":           "badX-Bad1: true",
+				"X-Tailscale-Name":            "alsobadX-Bad2: yes",
+				"X-Tailscale-Profile-Picture": "https://evil.comX-Bad3: absolutely",
+			},
+			description: "All injection attempts should be sanitized",
+		},
+		{
+			name: "profile picture URL should be included",
+			userProfile: &tailcfg.UserProfile{
+				LoginName:     "user@example.com",
+				DisplayName:   "Test User",
+				ProfilePicURL: "https://example.com/profile.jpg",
+			},
+			wantHeaders: map[string]string{
+				"X-Tailscale-User":            "user@example.com",
+				"X-Tailscale-Login":           "user@example.com",
+				"X-Tailscale-Name":            "Test User",
+				"X-Tailscale-Profile-Picture": "https://example.com/profile.jpg",
+			},
+			description: "Profile picture URL should be added as a header",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			whoisClient := &MockWhoisClient{
+				WhoIsFunc: func(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
+					return &apitype.WhoIsResponse{
+						UserProfile: tt.userProfile,
+					}, nil
+				},
+			}
+
+			nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for _, header := range []string{"X-Tailscale-User", "X-Tailscale-Login", "X-Tailscale-Name", "X-Tailscale-Profile-Picture"} {
+					if value := r.Header.Get(header); value != "" {
+						w.Header().Set(header, value)
+					}
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			middleware := Whois(whoisClient, true, 100*time.Millisecond, nil)
+			handler := middleware(nextHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.RemoteAddr = "100.64.1.2:12345"
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			for header, want := range tt.wantHeaders {
+				got := w.Header().Get(header)
+				if got != want {
+					t.Errorf("%s: header %s = %q, want %q", tt.description, header, got, want)
+				}
+			}
+
+			// Ensure no injected headers were added
+			for _, injectedHeader := range []string{"X-Injected", "X-Malicious", "X-Hack", "X-Bad1", "X-Bad2", "X-Bad3"} {
+				if got := w.Header().Get(injectedHeader); got != "" {
+					t.Errorf("Injected header %s should not exist, but got %q", injectedHeader, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeHeaderValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no special characters",
+			input: "normal-value",
+			want:  "normal-value",
+		},
+		{
+			name:  "carriage return",
+			input: "value\rwith\rCR",
+			want:  "valuewithCR",
+		},
+		{
+			name:  "line feed",
+			input: "value\nwith\nLF",
+			want:  "valuewithLF",
+		},
+		{
+			name:  "CRLF sequence",
+			input: "value\r\nwith\r\nCRLF",
+			want:  "valuewithCRLF",
+		},
+		{
+			name:  "mixed sequences",
+			input: "complex\rvalue\nwith\r\nmixed",
+			want:  "complexvaluewithmixed",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "only newlines",
+			input: "\r\n\r\n",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeHeaderValue(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeHeaderValue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add header sanitization to remove CR/LF characters from whois response data before setting HTTP headers. While we trust Tailscale's whois responses, this is a security best practice to prevent potential header injection attacks.

Changes:
- Add sanitizeHeaderValue function to strip \r and \n characters
- Apply sanitization to all user-provided header values
- Add X-Tailscale-Profile-Picture header support
- Add comprehensive tests for header injection prevention