### PR TITLE
feat: add configurable request body size limits

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,6 +234,9 @@ response_header_timeout = "0s"    # Maximum time to wait for response headers af
 
 # Response streaming
 flush_interval = "0s"             # Time between response flushes (default: 0s = default buffering; -1ms = immediate flush)
+
+# Request body size limit
+max_request_body_size = "50MB"    # Maximum allowed request body size (default: 50MB; -1 = no limit)
 ```
 
 ### Whois Configuration
@@ -244,6 +247,24 @@ Settings for Tailscale identity header injection:
 [global]
 whois_timeout = "1s"     # Maximum time to wait for whois lookup
 ```
+
+### Request Body Size Limits
+
+Control the maximum size of request bodies to prevent resource exhaustion:
+
+```toml
+[global]
+# Maximum request body size - supports human-readable formats
+max_request_body_size = "50MB"    # Default: 50MB
+```
+
+Supported formats:
+- Plain bytes: `"1048576"` (1MB in bytes)
+- Human-readable: `"10MB"`, `"5.5GiB"`, `"100KB"`
+- Supported units: B, KB, MB, GB, TB (decimal) and KiB, MiB, GiB, TiB (binary)
+- Disable limit: `"-1"` (allows unlimited request body size)
+
+**Important**: Setting `-1` disables the body size limit entirely. Use with caution as this can lead to resource exhaustion from large uploads.
 
 ### Security
 
@@ -374,6 +395,9 @@ idle_timeout = "300s"
 
 # Override logging
 access_log = false
+
+# Override request body size limit
+max_request_body_size = "100MB"  # Allow larger uploads for this service
 ```
 
 ## Environment Variables

--- a/example/tsbridge.toml
+++ b/example/tsbridge.toml
@@ -16,6 +16,11 @@ write_timeout = "30s"
 idle_timeout = "120s"
 shutdown_timeout = "15s"
 
+# Maximum request body size (default: 50MB)
+# This can be overridden per-service
+# Supports units: B, KB, MB, GB, TB (e.g., "10MB", "1.5GB", "100KB")
+# Use -1 to disable the limit entirely
+max_request_body_size = "50MB"
 
 # Whois configuration
 whois_timeout = "1s"
@@ -53,6 +58,22 @@ write_timeout = "60s"
 name = "demo-stream"
 backend_addr = "api-backend:8080"
 whois_enabled = true
-write_timeout = "0s"      # Disable write timeout for long-lived streams
-flush_interval = "-1ms"   # Immediate flushing for real-time streaming
-idle_timeout = "300s"     # Keep connections alive for 5 minutes
+write_timeout = "0s"              # Disable write timeout for long-lived streams
+flush_interval = "-1ms"           # Immediate flushing for real-time streaming
+idle_timeout = "300s"             # Keep connections alive for 5 minutes
+
+# Example of a service with custom request body size limit (e.g., file upload)
+[[services]]
+name = "demo-upload"
+backend_addr = "api-backend:8080"
+whois_enabled = true
+max_request_body_size = "100MB"   # Larger limit for file uploads
+write_timeout = "300s"            # Longer timeout for large uploads
+
+# Example of a service with no request body size limit
+[[services]]
+name = "demo-unlimited"
+backend_addr = "api-backend:8080"
+whois_enabled = true
+max_request_body_size = "-1"      # Disable body size limit (-1 means no limit)
+write_timeout = "600s"            # Very long timeout for unlimited uploads

--- a/internal/config/bytesize.go
+++ b/internal/config/bytesize.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ByteSize represents a size in bytes with support for human-readable parsing
+type ByteSize struct {
+	Value int64 // Size in bytes
+	IsSet bool  `mapstructure:"-" toml:"-" json:"-"` // Track if explicitly set
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler for ByteSize
+// Supports formats like: 1024, "1KB", "10MB", "1.5GB", "100MiB"
+// For compatibility, we treat KB/MB/GB as binary units (1KB = 1024 bytes)
+func (b *ByteSize) UnmarshalText(text []byte) error {
+	s := strings.TrimSpace(string(text))
+	if s == "" {
+		b.Value = 0
+		b.IsSet = false
+		return nil
+	}
+
+	// Try to parse as plain number first
+	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+		b.Value = v
+		b.IsSet = true
+		return nil
+	}
+
+	// Try to parse as float with unit suffix
+	var value float64
+	var unit string
+
+	// Find where the number ends and unit begins
+	i := 0
+	for i < len(s) && (s[i] >= '0' && s[i] <= '9' || s[i] == '.' || s[i] == ' ') {
+		i++
+	}
+
+	if i == 0 || i == len(s) {
+		return fmt.Errorf("invalid byte size format: %q", s)
+	}
+
+	// Parse the numeric part
+	numStr := strings.TrimSpace(s[:i])
+	unit = strings.TrimSpace(s[i:])
+
+	value, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return fmt.Errorf("invalid byte size format: %q", s)
+	}
+
+	if value < 0 {
+		return fmt.Errorf("byte size cannot be negative: %q", s)
+	}
+
+	// Convert unit to bytes
+	var multiplier int64
+	switch strings.ToUpper(unit) {
+	case "B", "BYTE", "BYTES":
+		multiplier = 1
+	case "K", "KB":
+		multiplier = 1024
+	case "KIB":
+		multiplier = 1024
+	case "M", "MB":
+		multiplier = 1024 * 1024
+	case "MIB":
+		multiplier = 1024 * 1024
+	case "G", "GB":
+		multiplier = 1024 * 1024 * 1024
+	case "GIB":
+		multiplier = 1024 * 1024 * 1024
+	case "T", "TB":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	case "TIB":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	case "P", "PB":
+		multiplier = 1024 * 1024 * 1024 * 1024 * 1024
+	case "PIB":
+		multiplier = 1024 * 1024 * 1024 * 1024 * 1024
+	default:
+		return fmt.Errorf("unknown unit %q in byte size: %q", unit, s)
+	}
+
+	b.Value = int64(value * float64(multiplier))
+	b.IsSet = true
+	return nil
+}
+
+// String returns the human-readable representation
+func (b ByteSize) String() string {
+	if !b.IsSet {
+		return ""
+	}
+
+	// Format as human-readable
+	const (
+		KB = 1024
+		MB = 1024 * KB
+		GB = 1024 * MB
+		TB = 1024 * GB
+		PB = 1024 * TB
+	)
+
+	switch {
+	case b.Value >= PB:
+		return formatSize(b.Value, PB, "PiB")
+	case b.Value >= TB:
+		return formatSize(b.Value, TB, "TiB")
+	case b.Value >= GB:
+		return formatSize(b.Value, GB, "GiB")
+	case b.Value >= MB:
+		return formatSize(b.Value, MB, "MiB")
+	case b.Value >= KB:
+		return formatSize(b.Value, KB, "KiB")
+	default:
+		return fmt.Sprintf("%dB", b.Value)
+	}
+}
+
+// formatSize formats a size value with the given divisor and unit
+func formatSize(value int64, divisor int64, unit string) string {
+	result := float64(value) / float64(divisor)
+	if result == float64(int64(result)) {
+		return fmt.Sprintf("%d%s", int64(result), unit)
+	}
+	return fmt.Sprintf("%.1f%s", result, unit)
+}
+
+// MarshalText implements encoding.TextMarshaler
+func (b ByteSize) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}

--- a/internal/config/bytesize_test.go
+++ b/internal/config/bytesize_test.go
@@ -1,0 +1,285 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestByteSizeUnmarshalText(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantValue int64
+		wantIsSet bool
+		wantErr   bool
+	}{
+		// Plain numbers
+		{
+			name:      "plain number",
+			input:     "1024",
+			wantValue: 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "zero",
+			input:     "0",
+			wantValue: 0,
+			wantIsSet: true,
+		},
+		{
+			name:      "negative number",
+			input:     "-1",
+			wantValue: -1,
+			wantIsSet: true,
+		},
+		// With units
+		{
+			name:      "kilobytes",
+			input:     "10KB",
+			wantValue: 10 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "megabytes",
+			input:     "5MB",
+			wantValue: 5 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "gigabytes",
+			input:     "2GB",
+			wantValue: 2 * 1024 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "terabytes",
+			input:     "1TB",
+			wantValue: 1024 * 1024 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		// Decimal values
+		{
+			name:      "decimal megabytes",
+			input:     "1.5MB",
+			wantValue: int64(1.5 * 1024 * 1024),
+			wantIsSet: true,
+		},
+		{
+			name:      "decimal gigabytes",
+			input:     "0.5GB",
+			wantValue: 512 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		// Case insensitive
+		{
+			name:      "lowercase units",
+			input:     "100mb",
+			wantValue: 100 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "mixed case",
+			input:     "50Mb",
+			wantValue: 50 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		// IEC units (binary)
+		{
+			name:      "kibibytes",
+			input:     "10KiB",
+			wantValue: 10 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "mebibytes",
+			input:     "5MiB",
+			wantValue: 5 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "gibibytes",
+			input:     "2GiB",
+			wantValue: 2 * 1024 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		// With spaces
+		{
+			name:      "spaces around",
+			input:     "  100MB  ",
+			wantValue: 100 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		// Negative with units
+		{
+			name:    "negative with units",
+			input:   "-5MB",
+			wantErr: true,
+		},
+		// Single letter units
+		{
+			name:      "single K",
+			input:     "10K",
+			wantValue: 10 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "single M",
+			input:     "5M",
+			wantValue: 5 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		{
+			name:      "single G",
+			input:     "2G",
+			wantValue: 2 * 1024 * 1024 * 1024,
+			wantIsSet: true,
+		},
+		// Edge cases
+		{
+			name:      "empty string",
+			input:     "",
+			wantValue: 0,
+			wantIsSet: false,
+		},
+		{
+			name:    "just unit",
+			input:   "MB",
+			wantErr: true,
+		},
+		{
+			name:    "invalid unit",
+			input:   "10XX",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			input:   "abc123",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b ByteSize
+			err := b.UnmarshalText([]byte(tt.input))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantValue, b.Value)
+			assert.Equal(t, tt.wantIsSet, b.IsSet)
+		})
+	}
+}
+
+func TestByteSizeString(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int64
+		isSet bool
+		want  string
+	}{
+		{
+			name:  "not set",
+			value: 0,
+			isSet: false,
+			want:  "",
+		},
+		{
+			name:  "zero bytes",
+			value: 0,
+			isSet: true,
+			want:  "0B",
+		},
+		{
+			name:  "bytes",
+			value: 512,
+			isSet: true,
+			want:  "512B",
+		},
+		{
+			name:  "exact kilobytes",
+			value: 10240,
+			isSet: true,
+			want:  "10KiB",
+		},
+		{
+			name:  "fractional kilobytes",
+			value: 10752,
+			isSet: true,
+			want:  "10.5KiB",
+		},
+		{
+			name:  "exact megabytes",
+			value: 5 * 1024 * 1024,
+			isSet: true,
+			want:  "5MiB",
+		},
+		{
+			name:  "fractional megabytes",
+			value: int64(5.5 * 1024 * 1024),
+			isSet: true,
+			want:  "5.5MiB",
+		},
+		{
+			name:  "gigabytes",
+			value: 2 * 1024 * 1024 * 1024,
+			isSet: true,
+			want:  "2GiB",
+		},
+		{
+			name:  "terabytes",
+			value: 1024 * 1024 * 1024 * 1024,
+			isSet: true,
+			want:  "1TiB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := ByteSize{
+				Value: tt.value,
+				IsSet: tt.isSet,
+			}
+			assert.Equal(t, tt.want, b.String())
+		})
+	}
+}
+
+func TestByteSizeMarshalText(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int64
+		isSet bool
+		want  string
+	}{
+		{
+			name:  "megabytes",
+			value: 10 * 1024 * 1024,
+			isSet: true,
+			want:  "10MiB",
+		},
+		{
+			name:  "not set",
+			value: 0,
+			isSet: false,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := ByteSize{
+				Value: tt.value,
+				IsSet: tt.isSet,
+			}
+			data, err := b.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+		})
+	}
+}

--- a/internal/config/compare.go
+++ b/internal/config/compare.go
@@ -74,6 +74,11 @@ func ServiceConfigEqual(a, b Service) bool {
 		return false
 	}
 
+	// Compare ByteSize pointer field
+	if !byteSizePtrEqual(a.MaxRequestBodySize, b.MaxRequestBodySize) {
+		return false
+	}
+
 	return true
 }
 
@@ -86,6 +91,17 @@ func boolPtrEqual(a, b *bool) bool {
 		return false
 	}
 	return *a == *b
+}
+
+// byteSizePtrEqual compares two ByteSize pointers
+func byteSizePtrEqual(a, b *ByteSize) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Value == b.Value && a.IsSet == b.IsSet
 }
 
 // durationEqual compares two Duration values

--- a/internal/config/compare_test.go
+++ b/internal/config/compare_test.go
@@ -475,6 +475,7 @@ func TestServiceConfigEqualCoversAllFields(t *testing.T) {
 		"DownstreamHeaders":     true,
 		"RemoveUpstream":        true,
 		"RemoveDownstream":      true,
+		"MaxRequestBodySize":    true,
 	}
 
 	// Check that all struct fields are in our comparison

--- a/internal/config/duration.go
+++ b/internal/config/duration.go
@@ -1,0 +1,38 @@
+// Package config handles configuration parsing and validation for tsbridge.
+package config
+
+import (
+	"time"
+)
+
+// Duration wraps time.Duration for TOML unmarshaling with explicit tracking
+type Duration struct {
+	time.Duration      // Embedded time.Duration value
+	IsSet         bool `mapstructure:"-" toml:"-" json:"-"` // Track if explicitly set
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler for Duration
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	if err == nil {
+		d.IsSet = true
+	}
+	return err
+}
+
+// MarshalText implements encoding.TextMarshaler for Duration
+func (d Duration) MarshalText() ([]byte, error) {
+	if !d.IsSet {
+		return []byte{}, nil
+	}
+	return []byte(d.Duration.String()), nil
+}
+
+// String returns the string representation of the duration
+func (d Duration) String() string {
+	if !d.IsSet {
+		return ""
+	}
+	return d.Duration.String()
+}

--- a/internal/config/duration_test.go
+++ b/internal/config/duration_test.go
@@ -1,0 +1,194 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDurationUnmarshalText(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantValue time.Duration
+		wantIsSet bool
+		wantErr   bool
+	}{
+		{
+			name:      "valid seconds",
+			input:     "30s",
+			wantValue: 30 * time.Second,
+			wantIsSet: true,
+		},
+		{
+			name:      "valid minutes",
+			input:     "5m",
+			wantValue: 5 * time.Minute,
+			wantIsSet: true,
+		},
+		{
+			name:      "valid hours",
+			input:     "2h",
+			wantValue: 2 * time.Hour,
+			wantIsSet: true,
+		},
+		{
+			name:      "valid milliseconds",
+			input:     "100ms",
+			wantValue: 100 * time.Millisecond,
+			wantIsSet: true,
+		},
+		{
+			name:      "valid microseconds",
+			input:     "50us",
+			wantValue: 50 * time.Microsecond,
+			wantIsSet: true,
+		},
+		{
+			name:      "valid nanoseconds",
+			input:     "1000ns",
+			wantValue: 1000 * time.Nanosecond,
+			wantIsSet: true,
+		},
+		{
+			name:      "valid complex duration",
+			input:     "1h30m45s",
+			wantValue: time.Hour + 30*time.Minute + 45*time.Second,
+			wantIsSet: true,
+		},
+		{
+			name:      "negative duration",
+			input:     "-5s",
+			wantValue: -5 * time.Second,
+			wantIsSet: true,
+		},
+		{
+			name:      "zero duration",
+			input:     "0s",
+			wantValue: 0,
+			wantIsSet: true,
+		},
+		{
+			name:      "special negative millisecond",
+			input:     "-1ms",
+			wantValue: -1 * time.Millisecond,
+			wantIsSet: true,
+		},
+		{
+			name:      "invalid format",
+			input:     "invalid",
+			wantErr:   true,
+			wantIsSet: false,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantErr:   true,
+			wantIsSet: false,
+		},
+		{
+			name:      "number without unit",
+			input:     "42",
+			wantErr:   true,
+			wantIsSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d Duration
+			err := d.UnmarshalText([]byte(tt.input))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.False(t, d.IsSet)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantValue, d.Duration)
+			assert.Equal(t, tt.wantIsSet, d.IsSet)
+		})
+	}
+}
+
+func TestDurationMarshalText(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration Duration
+		want     string
+	}{
+		{
+			name: "marshal seconds",
+			duration: Duration{
+				Duration: 30 * time.Second,
+				IsSet:    true,
+			},
+			want: "30s",
+		},
+		{
+			name: "marshal complex duration",
+			duration: Duration{
+				Duration: time.Hour + 30*time.Minute + 45*time.Second,
+				IsSet:    true,
+			},
+			want: "1h30m45s",
+		},
+		{
+			name: "marshal negative duration",
+			duration: Duration{
+				Duration: -5 * time.Second,
+				IsSet:    true,
+			},
+			want: "-5s",
+		},
+		{
+			name: "marshal not set",
+			duration: Duration{
+				Duration: 30 * time.Second,
+				IsSet:    false,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.duration.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestDurationString(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration Duration
+		want     string
+	}{
+		{
+			name: "string representation",
+			duration: Duration{
+				Duration: 5 * time.Minute,
+				IsSet:    true,
+			},
+			want: "5m0s",
+		},
+		{
+			name: "string when not set",
+			duration: Duration{
+				Duration: 5 * time.Minute,
+				IsSet:    false,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.duration.String())
+		})
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -68,3 +68,9 @@ const (
 	// DefaultTLSMode is the default TLS mode for services.
 	DefaultTLSMode = "auto"
 )
+
+// Default size limits used in configuration.
+const (
+	// DefaultMaxRequestBodySize is the default maximum request body size (50 MB).
+	DefaultMaxRequestBodySize = 50 * 1024 * 1024
+)

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -132,6 +132,13 @@ func (p *labelParser) getDuration(key string) config.Duration {
 	return result
 }
 
+// getByteSize gets a ByteSize pointer from labels
+func (p *labelParser) getByteSize(key string) *config.ByteSize {
+	value := p.getString(key)
+	result, _ := parseByteSize(value)
+	return result
+}
+
 // getStringSlice gets a string slice from labels
 func (p *labelParser) getStringSlice(key, separator string) []string {
 	value := p.getString(key)
@@ -213,6 +220,11 @@ func (p *Provider) parseGlobalConfig(container *container.Summary, cfg *config.C
 		FlushInterval:            parser.getDuration("global.flush_interval"),
 	}
 
+	// Handle MaxRequestBodySize separately since it's a ByteSize type
+	if bs := parser.getByteSize("global.max_request_body_size"); bs != nil {
+		cfg.Global.MaxRequestBodySize = *bs
+	}
+
 	return nil
 }
 
@@ -281,6 +293,7 @@ func (p *Provider) parseServiceConfig(container container.Summary) (*config.Serv
 	svc.DownstreamHeaders = parser.getHeaders("service.downstream_headers")
 	svc.RemoveUpstream = parser.getStringSlice("service.remove_upstream", ",")
 	svc.RemoveDownstream = parser.getStringSlice("service.remove_downstream", ",")
+	svc.MaxRequestBodySize = parser.getByteSize("service.max_request_body_size")
 
 	// Handle ephemeral (non-pointer bool)
 	if ephemeral := parser.getBool("service.ephemeral"); ephemeral != nil {
@@ -348,4 +361,16 @@ func parseStringSlice(value, separator string) []string {
 		parts[i] = strings.TrimSpace(parts[i])
 	}
 	return parts
+}
+
+// parseByteSize parses a byte size string and returns a pointer to ByteSize
+func parseByteSize(value string) (*config.ByteSize, error) {
+	if value == "" {
+		return nil, nil
+	}
+	var b config.ByteSize
+	if err := b.UnmarshalText([]byte(value)); err != nil {
+		return nil, err
+	}
+	return &b, nil
 }

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -135,7 +135,14 @@ func (p *labelParser) getDuration(key string) config.Duration {
 // getByteSize gets a ByteSize pointer from labels
 func (p *labelParser) getByteSize(key string) *config.ByteSize {
 	value := p.getString(key)
-	result, _ := parseByteSize(value)
+	result, err := parseByteSize(value)
+	if err != nil {
+		slog.Warn("failed to parse ByteSize from Docker label",
+			"key", key,
+			"value", value,
+			"error", err)
+		return nil
+	}
 	return result
 }
 

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -645,6 +645,7 @@ func getDockerParsedGlobalFields() map[string]bool {
 		"global.metrics_read_header_timeout": true,
 		"global.flush_interval":              true,
 		"global.default_tags":                true,
+		"global.max_request_body_size":       true,
 	}
 }
 
@@ -670,5 +671,6 @@ func getDockerParsedServiceFields() map[string]bool {
 		"service.remove_upstream":         true,
 		"service.remove_downstream":       true,
 		"service.tags":                    true,
+		"service.max_request_body_size":   true,
 	}
 }

--- a/internal/middleware/bodylimit.go
+++ b/internal/middleware/bodylimit.go
@@ -60,7 +60,7 @@ func (w *maxBytesResponseWriter) WriteHeader(statusCode int) {
 
 // Error is called by MaxBytesReader when the body exceeds the limit
 func (w *maxBytesResponseWriter) Error(msg string, code int) {
-	if msg == "http: request body too large" {
+	if code == http.StatusRequestEntityTooLarge {
 		w.oversized = true
 		// Don't write the error here, let our middleware handle it
 		return

--- a/internal/middleware/bodylimit.go
+++ b/internal/middleware/bodylimit.go
@@ -1,0 +1,70 @@
+// Package middleware implements HTTP middleware for request processing.
+package middleware
+
+import (
+	"net/http"
+)
+
+// MaxBytesHandler returns a middleware that limits the size of request bodies.
+// If maxBytes is negative, no limit is applied.
+func MaxBytesHandler(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if maxBytes < 0 {
+			// No limit
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check Content-Length header first for efficiency
+			if r.ContentLength > maxBytes {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+
+			// Wrap the body with MaxBytesReader
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+
+			// Use a custom response writer to catch MaxBytesError
+			rw := &maxBytesResponseWriter{
+				ResponseWriter: w,
+				written:        false,
+			}
+
+			next.ServeHTTP(rw, r)
+
+			// If MaxBytesReader detected oversized body, it calls our Error method
+			// Check if we need to send 413 response
+			if rw.oversized && !rw.written {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+			}
+		})
+	}
+}
+
+// maxBytesResponseWriter wraps http.ResponseWriter to intercept MaxBytesReader errors
+type maxBytesResponseWriter struct {
+	http.ResponseWriter
+	written   bool
+	oversized bool
+}
+
+func (w *maxBytesResponseWriter) Write(b []byte) (int, error) {
+	w.written = true
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *maxBytesResponseWriter) WriteHeader(statusCode int) {
+	w.written = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Error is called by MaxBytesReader when the body exceeds the limit
+func (w *maxBytesResponseWriter) Error(msg string, code int) {
+	if msg == "http: request body too large" {
+		w.oversized = true
+		// Don't write the error here, let our middleware handle it
+		return
+	}
+	// For other errors, use default behavior
+	http.Error(w, msg, code)
+}

--- a/internal/middleware/bodylimit_test.go
+++ b/internal/middleware/bodylimit_test.go
@@ -1,0 +1,152 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxBytesHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxBytes       int64
+		contentLength  string
+		bodySize       int
+		expectedStatus int
+		expectBodyRead bool
+	}{
+		{
+			name:           "request within limit",
+			maxBytes:       100,
+			bodySize:       50,
+			expectedStatus: http.StatusOK,
+			expectBodyRead: true,
+		},
+		{
+			name:           "request at limit",
+			maxBytes:       100,
+			bodySize:       100,
+			expectedStatus: http.StatusOK,
+			expectBodyRead: true,
+		},
+		{
+			name:           "request exceeds limit",
+			maxBytes:       100,
+			bodySize:       150,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+			expectBodyRead: false,
+		},
+		{
+			name:           "request with content-length exceeds limit",
+			maxBytes:       100,
+			contentLength:  "150",
+			bodySize:       150,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+			expectBodyRead: false,
+		},
+		{
+			name:           "negative limit disables check",
+			maxBytes:       -1,
+			bodySize:       1000,
+			expectedStatus: http.StatusOK,
+			expectBodyRead: true,
+		},
+		{
+			name:           "zero body allowed",
+			maxBytes:       100,
+			bodySize:       0,
+			expectedStatus: http.StatusOK,
+			expectBodyRead: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Track if the handler was called
+			handlerCalled := false
+			bodyRead := false
+
+			// Create test handler
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				body, err := io.ReadAll(r.Body)
+				if err == nil {
+					bodyRead = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(body)
+				} else {
+					// If we get an error reading the body, it's likely due to MaxBytesReader
+					w.WriteHeader(http.StatusBadRequest)
+				}
+			})
+
+			// Wrap with MaxBytesHandler
+			wrapped := MaxBytesHandler(tt.maxBytes)(handler)
+
+			// Create request
+			body := bytes.Repeat([]byte("x"), tt.bodySize)
+			req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
+
+			// Set Content-Length if specified
+			if tt.contentLength != "" {
+				req.Header.Set("Content-Length", tt.contentLength)
+				req.ContentLength = int64(tt.bodySize)
+			}
+
+			// Execute request
+			recorder := httptest.NewRecorder()
+			wrapped.ServeHTTP(recorder, req)
+
+			// Check results
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.expectBodyRead {
+				assert.True(t, handlerCalled, "handler should have been called")
+				assert.True(t, bodyRead, "body should have been read")
+				if tt.bodySize > 0 {
+					assert.Equal(t, body, recorder.Body.Bytes(), "response should echo request body")
+				}
+			} else {
+				// For content-length check, handler might not be called at all
+				if tt.contentLength != "" && tt.maxBytes > 0 {
+					assert.False(t, handlerCalled, "handler should not have been called")
+				}
+				assert.Contains(t, recorder.Body.String(), "Request body too large")
+			}
+		})
+	}
+}
+
+func TestMaxBytesHandler_ChunkedEncoding(t *testing.T) {
+	// Test with chunked encoding (no Content-Length header)
+	maxBytes := int64(100)
+	bodySize := 150
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			// MaxBytesReader will cause an error when limit is exceeded
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := MaxBytesHandler(maxBytes)(handler)
+
+	// Create request without Content-Length (simulating chunked encoding)
+	body := strings.Repeat("x", bodySize)
+	req := httptest.NewRequest("POST", "/test", strings.NewReader(body))
+	req.ContentLength = -1 // Force chunked encoding
+
+	recorder := httptest.NewRecorder()
+	wrapped.ServeHTTP(recorder, req)
+
+	// The handler will be called but reading the body will fail
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -286,10 +286,16 @@ func (s *Service) isAccessLogEnabled() bool {
 // It returns the service-specific override if set, otherwise the global value
 // A negative value means no limit should be applied
 func (s *Service) getMaxRequestBodySize() int64 {
-	if s.Config.MaxRequestBodySize != nil {
+	if s.Config.MaxRequestBodySize != nil && s.Config.MaxRequestBodySize.IsSet {
+		if s.Config.MaxRequestBodySize.Value == 0 {
+			return constants.DefaultMaxRequestBodySize
+		}
 		return s.Config.MaxRequestBodySize.Value
 	}
-	if s.globalConfig != nil {
+	if s.globalConfig != nil && s.globalConfig.Global.MaxRequestBodySize.IsSet {
+		if s.globalConfig.Global.MaxRequestBodySize.Value == 0 {
+			return constants.DefaultMaxRequestBodySize
+		}
 		return s.globalConfig.Global.MaxRequestBodySize.Value
 	}
 	// Default if no config available

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -228,6 +228,12 @@ func (s *Service) CreateHandler() (http.Handler, error) {
 	// Wrap with request ID middleware - this should be early in the chain
 	httpHandler = middleware.RequestID(httpHandler)
 
+	// Apply request body size limit
+	maxBodySize := s.getMaxRequestBodySize()
+	if maxBodySize > 0 {
+		httpHandler = middleware.MaxBytesHandler(maxBodySize)(httpHandler)
+	}
+
 	// Wrap with whois middleware if enabled
 	whoisEnabled := s.Config.WhoisEnabled != nil && *s.Config.WhoisEnabled
 	if whoisEnabled && s.tsServer != nil {
@@ -274,6 +280,20 @@ func (s *Service) isAccessLogEnabled() bool {
 	}
 	// Default to true
 	return true
+}
+
+// getMaxRequestBodySize returns the max request body size for this service
+// It returns the service-specific override if set, otherwise the global value
+// A negative value means no limit should be applied
+func (s *Service) getMaxRequestBodySize() int64 {
+	if s.Config.MaxRequestBodySize != nil {
+		return s.Config.MaxRequestBodySize.Value
+	}
+	if s.globalConfig != nil {
+		return s.globalConfig.Global.MaxRequestBodySize.Value
+	}
+	// Default if no config available
+	return constants.DefaultMaxRequestBodySize
 }
 
 // Stop gracefully stops the service
@@ -456,7 +476,12 @@ func (r *Registry) validateServiceConfig(cfg config.Service) error {
 		}
 	} else {
 		// TCP address validation
-		if _, err := url.Parse(cfg.BackendAddr); err != nil {
+		// Add scheme if missing, consistent with proxy.parseBackendURL
+		addr := cfg.BackendAddr
+		if !strings.Contains(addr, "://") {
+			addr = "http://" + addr
+		}
+		if _, err := url.Parse(addr); err != nil {
 			return fmt.Errorf("invalid backend address: %w", err)
 		}
 	}


### PR DESCRIPTION
- Add ByteSize type for human-readable size parsing (KB, MB, GB, KiB, MiB, GiB)
- Implement request body limit middleware returning proper 413 status codes
- Add MaxRequestBodySize to global and per-service configuration
- Support Docker label configuration for body size limits
- Refactor Duration type to separate file for consistency
- Set default limit to 50MB
- Document -1 value to disable limits entirely
- Add comprehensive tests for ByteSize parsing and middleware

The implementation supports:
- Human-readable formats: "10MB", "5.5GiB", "1024", etc.
- Global defaults with per-service overrides
- Plain negative values (-1) to disable limits
- Efficient Content-Length header pre-checks