### PR TITLE
fix: improve OAuth auth key security posture

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -47,11 +47,12 @@ const (
 	DefaultMetricsReadHeaderTimeout = 5 * time.Second
 )
 
-// OAuth constants define OAuth-related configuration.
+// Auth key constants define Tailscale auth key configuration.
 const (
-	// OAuthTokenExpirySeconds is the expiry time for OAuth tokens in seconds (90 days).
-	// This is a reasonable default that balances security with user convenience.
-	OAuthTokenExpirySeconds = 90 * 24 * 60 * 60 // 90 days in seconds
+	// AuthKeyExpirySeconds is the expiry time for Tailscale auth keys in seconds (5 minutes).
+	// These auth keys are used once for service registration and then discarded,
+	// so a short expiry minimizes the security exposure window.
+	AuthKeyExpirySeconds = 5 * 60 // 5 minutes in seconds
 )
 
 // Default boolean values used in configuration.

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -52,18 +52,18 @@ func TestTimeoutConstants(t *testing.T) {
 	}
 }
 
-func TestOAuthConstants(t *testing.T) {
-	// OAuth token expiry is 90 days in seconds
-	expectedExpiry := 90 * 24 * 60 * 60
-	if OAuthTokenExpirySeconds != expectedExpiry {
-		t.Errorf("OAuthTokenExpirySeconds = %d, want %d", OAuthTokenExpirySeconds, expectedExpiry)
+func TestAuthKeyConstants(t *testing.T) {
+	// Auth key expiry is 5 minutes in seconds
+	expectedExpiry := 5 * 60
+	if AuthKeyExpirySeconds != expectedExpiry {
+		t.Errorf("AuthKeyExpirySeconds = %d, want %d", AuthKeyExpirySeconds, expectedExpiry)
 	}
 
-	// Verify it equals 90 days
-	expectedDays := 90
-	actualDays := OAuthTokenExpirySeconds / (24 * 60 * 60)
-	if actualDays != expectedDays {
-		t.Errorf("OAuthTokenExpirySeconds represents %d days, want %d days", actualDays, expectedDays)
+	// Verify it equals 5 minutes
+	expectedMinutes := 5
+	actualMinutes := AuthKeyExpirySeconds / 60
+	if actualMinutes != expectedMinutes {
+		t.Errorf("AuthKeyExpirySeconds represents %d minutes, want %d minutes", actualMinutes, expectedMinutes)
 	}
 }
 

--- a/internal/tailscale/oauth.go
+++ b/internal/tailscale/oauth.go
@@ -64,12 +64,12 @@ func generateAuthKeyWithOAuth(oauthConfig *oauth2.Config, apiBaseURL string, tag
 
 	// Create auth key request
 	req := authKeyRequest{
-		ExpirySeconds: constants.OAuthTokenExpirySeconds,
+		ExpirySeconds: constants.AuthKeyExpirySeconds,
 		Tags:          tags,
 	}
 
 	// Set capabilities
-	req.Capabilities.Devices.Create.Reusable = true
+	req.Capabilities.Devices.Create.Reusable = false
 	req.Capabilities.Devices.Create.Ephemeral = ephemeral
 	req.Capabilities.Devices.Create.Tags = tags
 	req.Capabilities.Devices.Create.PreauthorizeOnly = false
@@ -144,6 +144,12 @@ func generateOrResolveAuthKey(cfg config.Config, svc config.Service) (string, er
 			// Error from generateAuthKeyWithOAuth is already typed
 			return "", err
 		}
+
+		// Log auth key generation for audit trail
+		slog.Info("Generated Tailscale auth key for service registration",
+			"service", svc.Name,
+		)
+
 		return authKey, nil
 	}
 

--- a/internal/tailscale/oauth_test.go
+++ b/internal/tailscale/oauth_test.go
@@ -1,11 +1,14 @@
 package tailscale
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -454,6 +457,11 @@ func TestOAuthEphemeralFlag(t *testing.T) {
 			if req.Capabilities.Devices.Create.Ephemeral != tt.ephemeral {
 				t.Errorf("expected ephemeral=%v, got %v", tt.ephemeral, req.Capabilities.Devices.Create.Ephemeral)
 			}
+
+			// Verify reusable is always false for security
+			if req.Capabilities.Devices.Create.Reusable != false {
+				t.Errorf("expected reusable=false, got %v", req.Capabilities.Devices.Create.Reusable)
+			}
 		})
 	}
 }
@@ -470,4 +478,124 @@ func TestCredentialResolutionErrorTypes(t *testing.T) {
 			t.Errorf("expected config error, got %v", err)
 		}
 	})
+}
+
+func TestAuthKeyNonReusable(t *testing.T) {
+	// Track the request body to verify reusable flag
+	var requestBody []byte
+
+	// Create mock servers
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token": "test-token", "token_type": "Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the request body
+		body, _ := io.ReadAll(r.Body)
+		requestBody = body
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"key": "test-auth-key"}`))
+	}))
+	defer apiServer.Close()
+
+	oauthConfig := &oauth2.Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Endpoint: oauth2.Endpoint{
+			TokenURL: tokenServer.URL + "/oauth/token",
+		},
+	}
+
+	// Generate auth key
+	_, err := generateAuthKeyWithOAuth(oauthConfig, apiServer.URL, []string{"tag:test"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Parse the request body to check reusable flag
+	var req authKeyRequest
+	if err := json.Unmarshal(requestBody, &req); err != nil {
+		t.Fatalf("failed to unmarshal request body: %v", err)
+	}
+
+	// Verify reusable flag is false for better security
+	if req.Capabilities.Devices.Create.Reusable != false {
+		t.Errorf("expected reusable=false for single-use auth keys, got %v", req.Capabilities.Devices.Create.Reusable)
+	}
+}
+
+func TestAuthKeyGenerationLogging(t *testing.T) {
+	// Create a buffer to capture log output
+	var logBuf bytes.Buffer
+
+	// Set up custom logger to capture output
+	originalLogger := slog.Default()
+	testLogger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	slog.SetDefault(testLogger)
+	defer slog.SetDefault(originalLogger)
+
+	// Create a single server that handles both OAuth token and API endpoints
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/oauth/token":
+			// Handle OAuth token request
+			token := map[string]interface{}{
+				"access_token": "mock-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}
+			_ = json.NewEncoder(w).Encode(token)
+		case "/api/v2/tailnet/-/keys":
+			// Handle API request
+			response := map[string]interface{}{
+				"key":     "tskey-auth-mock123",
+				"created": time.Now().Format(time.RFC3339),
+			}
+			_ = json.NewEncoder(w).Encode(response)
+		}
+	}))
+	defer server.Close()
+
+	// Set up test environment
+	t.Setenv("TSBRIDGE_OAUTH_ENDPOINT", server.URL)
+
+	// Test with OAuth credentials
+	cfg := config.Config{
+		Tailscale: config.Tailscale{
+			OAuthClientID:     "test-client-id",
+			OAuthClientSecret: "test-client-secret",
+		},
+	}
+
+	svc := config.Service{
+		Name:      "test-service",
+		Tags:      []string{"tag:api"},
+		Ephemeral: false,
+	}
+
+	// Generate auth key using OAuth
+	authKey, err := generateOrResolveAuthKey(cfg, svc)
+	if err != nil {
+		t.Fatalf("failed to generate auth key: %v", err)
+	}
+
+	if authKey != "tskey-auth-mock123" {
+		t.Errorf("expected tskey-auth-mock123, got %s", authKey)
+	}
+
+	// Check that auth key generation was logged
+	logOutput := logBuf.String()
+	if !strings.Contains(logOutput, "Generated Tailscale auth key for service registration") {
+		t.Error("expected auth key generation to be logged")
+	}
+	if !strings.Contains(logOutput, `service=test-service`) {
+		t.Error("expected service name in log")
+	}
 }

--- a/internal/tailscale/oauth_test.go
+++ b/internal/tailscale/oauth_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jtdowney/tsbridge/internal/config"
+	"github.com/jtdowney/tsbridge/internal/constants"
 	"github.com/jtdowney/tsbridge/internal/errors"
 	"golang.org/x/oauth2"
 )
@@ -394,6 +395,16 @@ func TestGenerateOrResolveAuthKeyWithServiceTags(t *testing.T) {
 	if len(req.Tags) != 2 || req.Tags[0] != "tag:api" || req.Tags[1] != "tag:prod" {
 		t.Errorf("expected service tags [tag:api tag:prod], got %v", req.Tags)
 	}
+
+	// Verify expiry is set to 5 minutes
+	if req.ExpirySeconds != constants.AuthKeyExpirySeconds {
+		t.Errorf("expected expiry=%d seconds, got %d", constants.AuthKeyExpirySeconds, req.ExpirySeconds)
+	}
+
+	// Verify reusable is false
+	if req.Capabilities.Devices.Create.Reusable != false {
+		t.Errorf("expected reusable=false, got %v", req.Capabilities.Devices.Create.Reusable)
+	}
 }
 
 func TestOAuthEphemeralFlag(t *testing.T) {
@@ -524,6 +535,11 @@ func TestAuthKeyNonReusable(t *testing.T) {
 	// Verify reusable flag is false for better security
 	if req.Capabilities.Devices.Create.Reusable != false {
 		t.Errorf("expected reusable=false for single-use auth keys, got %v", req.Capabilities.Devices.Create.Reusable)
+	}
+
+	// Verify expiry is set to 5 minutes
+	if req.ExpirySeconds != constants.AuthKeyExpirySeconds {
+		t.Errorf("expected expiry=%d seconds, got %d", constants.AuthKeyExpirySeconds, req.ExpirySeconds)
 	}
 }
 


### PR DESCRIPTION
- Reduce auth key expiry from 90 days to 5 minutes
- Make auth keys non-reusable (single-use only)
- Rename OAuthTokenExpirySeconds to AuthKeyExpirySeconds for clarity
- Change auth key generation from warning to info log

These auth keys are only used once during initial service registration, then tsnet stores credentials locally. The 90-day expiry window was unnecessarily long for single-use tokens, creating a security risk if keys were compromised.