### PR TITLE
fix: respect explicitly set zero value for max_request_body_size

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -287,18 +287,14 @@ func (s *Service) isAccessLogEnabled() bool {
 // A negative value means no limit should be applied
 func (s *Service) getMaxRequestBodySize() int64 {
 	if s.Config.MaxRequestBodySize != nil && s.Config.MaxRequestBodySize.IsSet {
-		if s.Config.MaxRequestBodySize.Value == 0 {
-			return constants.DefaultMaxRequestBodySize
-		}
+		// If explicitly set, use the value as-is. 0 is a valid explicit limit.
 		return s.Config.MaxRequestBodySize.Value
 	}
 	if s.globalConfig != nil && s.globalConfig.Global.MaxRequestBodySize.IsSet {
-		if s.globalConfig.Global.MaxRequestBodySize.Value == 0 {
-			return constants.DefaultMaxRequestBodySize
-		}
+		// If explicitly set globally, use the value as-is.
 		return s.globalConfig.Global.MaxRequestBodySize.Value
 	}
-	// Default if no config available
+	// Default if no config available or not explicitly set anywhere
 	return constants.DefaultMaxRequestBodySize
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -2028,6 +2028,14 @@ func TestMaxRequestBodySize(t *testing.T) {
 			expectedStatus:     http.StatusOK,
 			expectBodyRead:     true,
 		},
+		{
+			name:               "explicitly set zero limit blocks all requests",
+			globalMaxBodySize:  config.ByteSize{Value: 1024, IsSet: true},
+			serviceMaxBodySize: &config.ByteSize{Value: 0, IsSet: true},
+			requestBodySize:    1,
+			expectedStatus:     http.StatusRequestEntityTooLarge,
+			expectBodyRead:     false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Previously, the code incorrectly treated an explicitly configured value of 0 as if it were unset, reverting to the default limit. This prevented users from setting a true zero-byte body limit.

- Remove zero-value checks in getMaxRequestBodySize()
- Rely solely on ByteSize.IsSet flag to determine if value was configured
- Add test case verifying zero limit blocks all request bodies