### PR TITLE
chore: auto-cleanup architecture-specific Docker tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,8 @@ jobs:
             ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-amd64 \
             ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}-arm64
           docker manifest push ghcr.io/jtdowney/tsbridge:sha-${SHA_SHORT}
+          
+          # Clean up architecture-specific tags
+          echo "Cleaning up architecture-specific tags..."
+          ./scripts/cleanup-arch-tags.sh "pr-${PR_NUMBER}"
+          ./scripts/cleanup-arch-tags.sh "sha-${SHA_SHORT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,5 +96,5 @@ jobs:
           
           # Clean up architecture-specific tags
           echo "Cleaning up architecture-specific tags..."
-          ./scripts/cleanup-arch-tags.sh "pr-${PR_NUMBER}"
-          ./scripts/cleanup-arch-tags.sh "sha-${SHA_SHORT}"
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} ./scripts/cleanup-arch-tags.sh "pr-${PR_NUMBER}"
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} ./scripts/cleanup-arch-tags.sh "sha-${SHA_SHORT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Clean up architecture-specific Docker tags
+        run: |
+          # Extract the tag from the ref
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "Cleaning up architecture-specific tags for release ${TAG}"
+          ./scripts/cleanup-arch-tags.sh "${TAG}"
+          ./scripts/cleanup-arch-tags.sh "latest"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         if: always()

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,14 +77,6 @@ docker_manifests:
       - "ghcr.io/jtdowney/tsbridge:latest-amd64"
       - "ghcr.io/jtdowney/tsbridge:latest-arm64"
 
-after:
-  hooks:
-    - cmd: ./scripts/cleanup-arch-tags.sh "{{ .Tag }}"
-      env:
-        - GITHUB_TOKEN={{ .Env.GITHUB_TOKEN }}
-    - cmd: ./scripts/cleanup-arch-tags.sh "latest"
-      env:
-        - GITHUB_TOKEN={{ .Env.GITHUB_TOKEN }}
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,6 +77,15 @@ docker_manifests:
       - "ghcr.io/jtdowney/tsbridge:latest-amd64"
       - "ghcr.io/jtdowney/tsbridge:latest-arm64"
 
+after:
+  hooks:
+    - cmd: ./scripts/cleanup-arch-tags.sh "{{ .Tag }}"
+      env:
+        - GITHUB_TOKEN={{ .Env.GITHUB_TOKEN }}
+    - cmd: ./scripts/cleanup-arch-tags.sh "latest"
+      env:
+        - GITHUB_TOKEN={{ .Env.GITHUB_TOKEN }}
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/scripts/cleanup-arch-tags.sh
+++ b/scripts/cleanup-arch-tags.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# Script to clean up architecture-specific Docker image tags
+# Usage: ./cleanup-arch-tags.sh [--dry-run] <tag-pattern>
+# Example: ./cleanup-arch-tags.sh --dry-run "pr-123"
+# Example: ./cleanup-arch-tags.sh "v0.7.0"
+
+set -euo pipefail
+
+# Configuration
+REGISTRY="ghcr.io"
+OWNER="jtdowney"
+PACKAGE_NAME="tsbridge"
+PACKAGE_TYPE="container"
+
+# Parse arguments
+DRY_RUN=false
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 [--dry-run] <tag-pattern>"
+    echo "Example: $0 --dry-run pr-123"
+    echo "Example: $0 v0.7.0"
+    exit 1
+fi
+
+if [ "$1" = "--dry-run" ]; then
+    DRY_RUN=true
+    shift
+fi
+
+TAG_PATTERN="${1:-}"
+
+if [ -z "$TAG_PATTERN" ]; then
+    echo "Error: Tag pattern is required"
+    exit 1
+fi
+
+# Check for required environment variables
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "Error: GITHUB_TOKEN environment variable is required"
+    echo "Generate a token with 'delete:packages' permission at https://github.com/settings/tokens"
+    exit 1
+fi
+
+echo "Configuration:"
+echo "  Registry: $REGISTRY"
+echo "  Owner: $OWNER"
+echo "  Package: $PACKAGE_NAME"
+echo "  Tag pattern: $TAG_PATTERN"
+echo "  Dry run: $DRY_RUN"
+echo ""
+
+# Function to delete a specific version
+delete_version() {
+    local version_id=$1
+    local tag=$2
+    
+    if [ "$DRY_RUN" = true ]; then
+        echo "[DRY RUN] Would delete version ID: ${version_id} (tag: ${tag})"
+    else
+        echo "Deleting version ID: ${version_id} (tag: ${tag})"
+        response=$(curl -s -w "\n%{http_code}" -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/user/packages/${PACKAGE_TYPE}/${PACKAGE_NAME}/versions/${version_id}")
+        
+        http_code=$(echo "$response" | tail -n1)
+        body=$(echo "$response" | sed '$d')
+        
+        if [ "$http_code" = "204" ]; then
+            echo "  ✓ Successfully deleted"
+        else
+            echo "  ✗ Failed to delete (HTTP ${http_code})"
+            if [ -n "$body" ]; then
+                echo "  Response: $body"
+            fi
+        fi
+    fi
+}
+
+# Architecture suffixes to look for
+ARCH_SUFFIXES=("-amd64" "-arm64")
+
+echo "Fetching package versions..."
+
+# Get all versions (paginated)
+page=1
+all_versions=""
+
+while true; do
+    response=$(curl -s -w "\n%{http_code}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/user/packages/${PACKAGE_TYPE}/${PACKAGE_NAME}/versions?per_page=100&page=${page}")
+    
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+    
+    if [ "$http_code" != "200" ]; then
+        echo "Error fetching package versions (HTTP ${http_code})"
+        echo "Response: $body"
+        exit 1
+    fi
+    
+    # Check if we got any results
+    if [ "$(echo "$body" | jq -r '. | length')" -eq 0 ]; then
+        break
+    fi
+    
+    all_versions="${all_versions}${body}"
+    page=$((page + 1))
+done
+
+# Process versions
+echo ""
+echo "Searching for architecture-specific tags matching pattern: ${TAG_PATTERN}"
+echo ""
+
+found_count=0
+deleted_count=0
+
+for suffix in "${ARCH_SUFFIXES[@]}"; do
+    # Look for tags matching the pattern with architecture suffix
+    tags_to_check=("${TAG_PATTERN}${suffix}")
+    
+    # If pattern looks like a version tag, also check "latest" variants
+    if [[ "$TAG_PATTERN" =~ ^v[0-9] ]]; then
+        tags_to_check+=("latest${suffix}")
+    fi
+    
+    for tag in "${tags_to_check[@]}"; do
+        # Find version IDs for this tag
+        version_ids=$(echo "$all_versions" | jq -r ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id")
+        
+        if [ -n "$version_ids" ]; then
+            while IFS= read -r version_id; do
+                found_count=$((found_count + 1))
+                delete_version "$version_id" "$tag"
+                if [ "$DRY_RUN" = false ]; then
+                    deleted_count=$((deleted_count + 1))
+                fi
+            done <<< "$version_ids"
+        fi
+    done
+done
+
+echo ""
+echo "Summary:"
+echo "  Found: ${found_count} architecture-specific tags"
+if [ "$DRY_RUN" = true ]; then
+    echo "  This was a dry run. No tags were deleted."
+    echo "  Run without --dry-run to actually delete the tags."
+else
+    echo "  Deleted: ${deleted_count} tags"
+fi


### PR DESCRIPTION
- Add cleanup script to remove -amd64/-arm64 tags after multi-arch manifest creation
- Update CI workflow to clean up arch tags for PR builds
- Add GoReleaser hooks to clean up arch tags after releases
- Reduces clutter in GitHub Container Registry by removing intermediate build artifacts