### PR TITLE
chore: add minor version tags to Docker releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,23 @@ jobs:
           # Extract the tag from the ref
           TAG=${GITHUB_REF#refs/tags/}
           echo "Cleaning up architecture-specific tags for release ${TAG}"
+          
+          # Clean up full version tag (e.g., v0.7.1)
           ./scripts/cleanup-arch-tags.sh "${TAG}"
+          
+          # Clean up minor version tag (e.g., 0.7)
+          # Extract major.minor from tag (remove 'v' prefix and patch version)
+          MINOR_TAG=$(echo "${TAG}" | sed -E 's/^v?([0-9]+\.[0-9]+).*/\1/')
+          ./scripts/cleanup-arch-tags.sh "${MINOR_TAG}"
+          
+          # Clean up latest tag
           ./scripts/cleanup-arch-tags.sh "latest"
+          
+          # TODO: For 1.0.0+ releases, also clean up major version tags
+          # MAJOR_TAG=$(echo "${TAG}" | sed -E 's/^v?([0-9]+).*/\1/')
+          # if [ "${MAJOR_TAG}" != "0" ]; then
+          #   ./scripts/cleanup-arch-tags.sh "${MAJOR_TAG}"
+          # fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,9 @@ dockers:
   - image_templates:
       - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-amd64"
       - "ghcr.io/jtdowney/tsbridge:latest-amd64"
+      - "ghcr.io/jtdowney/tsbridge:{{ .Major }}.{{ .Minor }}-amd64"
+      # TODO: Uncomment for 1.0.0 release
+      # - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-amd64"
     dockerfile: Dockerfile
     goos: linux
     goarch: amd64
@@ -51,6 +54,9 @@ dockers:
   - image_templates:
       - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-arm64"
       - "ghcr.io/jtdowney/tsbridge:latest-arm64"
+      - "ghcr.io/jtdowney/tsbridge:{{ .Major }}.{{ .Minor }}-arm64"
+      # TODO: Uncomment for 1.0.0 release
+      # - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-arm64"
     dockerfile: Dockerfile
     goos: linux
     goarch: arm64
@@ -72,6 +78,15 @@ docker_manifests:
     image_templates:
       - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-amd64"
       - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/jtdowney/tsbridge:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/jtdowney/tsbridge:{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/jtdowney/tsbridge:{{ .Major }}.{{ .Minor }}-arm64"
+  # TODO: Uncomment for 1.0.0 release
+  # - name_template: "ghcr.io/jtdowney/tsbridge:{{ .Major }}"
+  #   image_templates:
+  #     - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-amd64"
+  #     - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-arm64"
   - name_template: "ghcr.io/jtdowney/tsbridge:latest"
     image_templates:
       - "ghcr.io/jtdowney/tsbridge:latest-amd64"


### PR DESCRIPTION
- Configure GoReleaser to create major.minor version tags (e.g., 0.7)
- Update cleanup script to remove architecture-specific minor version tags
- Add commented configuration for future major version tags (1.0.0+)