### PR TITLE
feat: add FreeBSD deployment support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
     goos:
       - linux
       - darwin
+      - freebsd
     goarch:
       - amd64
       - arm64

--- a/deployments/freebsd/README.md
+++ b/deployments/freebsd/README.md
@@ -1,0 +1,318 @@
+# FreeBSD Deployment Guide for tsbridge
+
+This guide covers deploying tsbridge on FreeBSD systems using the rc.d init system.
+
+## Prerequisites
+
+- FreeBSD
+- Go 1.24+ (for building from source)
+- Tailscale OAuth client credentials
+
+## Installation
+
+### Option 1: Download Pre-built Binary
+
+Download the latest FreeBSD binary from the [releases page](https://github.com/jtdowney/tsbridge/releases):
+
+```bash
+# For amd64
+fetch https://github.com/jtdowney/tsbridge/releases/latest/download/tsbridge_VERSION_freebsd_amd64.tar.gz
+tar -xzf tsbridge_VERSION_freebsd_amd64.tar.gz
+install -m 755 tsbridge /usr/local/bin/
+
+# For arm64
+fetch https://github.com/jtdowney/tsbridge/releases/latest/download/tsbridge_VERSION_freebsd_arm64.tar.gz
+tar -xzf tsbridge_VERSION_freebsd_arm64.tar.gz
+install -m 755 tsbridge /usr/local/bin/
+```
+
+### Option 2: Build from Source
+
+```bash
+git clone https://github.com/jtdowney/tsbridge.git
+cd tsbridge
+make build
+install -m 755 tsbridge /usr/local/bin/
+```
+
+## System Setup
+
+### 1. Create User and Group
+
+```bash
+# Create tsbridge user and group
+pw groupadd tsbridge
+pw useradd tsbridge -g tsbridge -d /nonexistent -s /usr/sbin/nologin -c "tsbridge daemon"
+```
+
+### 2. Create Required Directories
+
+```bash
+# Configuration directory
+install -d -o root -g wheel -m 755 /usr/local/etc/tsbridge
+
+# Runtime directories (will be created by rc script, but can be pre-created)
+install -d -o tsbridge -g tsbridge -m 750 /var/run/tsbridge
+install -d -o tsbridge -g tsbridge -m 750 /var/log/tsbridge
+install -d -o tsbridge -g tsbridge -m 750 /var/db/tsbridge
+```
+
+### 3. Install Configuration
+
+Copy the example configuration and customize it:
+
+```bash
+cp /path/to/tsbridge/deployments/freebsd/config.example.toml /usr/local/etc/tsbridge/config.toml
+```
+
+Basic configuration example at `/usr/local/etc/tsbridge/config.toml`:
+
+```toml
+# Tailscale authentication (required)
+[tailscale]
+oauth_client_id_file = "/usr/local/etc/tsbridge/oauth_client_id"
+oauth_client_secret_file = "/usr/local/etc/tsbridge/oauth_client_secret"
+state_dir = "/var/db/tsbridge"
+default_tags = ["tag:server", "tag:tsbridge"]
+
+# Global defaults (optional)
+[global]
+access_log = true
+metrics_addr = ":9100"
+whois_timeout = "1s"
+
+# Services (at least one required)
+[[services]]
+name = "wiki"
+backend_addr = "127.0.0.1:8080"
+whois_enabled = true
+```
+
+See `config.example.toml` for a complete configuration reference with all available options.
+
+### 4. Configure OAuth Credentials
+
+Store your Tailscale OAuth credentials securely:
+
+```bash
+# Save OAuth client ID
+echo "YOUR_CLIENT_ID" > /usr/local/etc/tsbridge/oauth_client_id
+chmod 600 /usr/local/etc/tsbridge/oauth_client_id
+chown tsbridge:tsbridge /usr/local/etc/tsbridge/oauth_client_id
+
+# Save OAuth client secret
+echo "YOUR_CLIENT_SECRET" > /usr/local/etc/tsbridge/oauth_client_secret
+chmod 600 /usr/local/etc/tsbridge/oauth_client_secret
+chown tsbridge:tsbridge /usr/local/etc/tsbridge/oauth_client_secret
+```
+
+### 5. Install rc.d Script
+
+```bash
+# Copy the rc.d script
+install -m 755 tsbridge /usr/local/etc/rc.d/tsbridge
+```
+
+## Service Management
+
+### Enable the Service
+
+Add to `/etc/rc.conf`:
+
+```bash
+# Basic configuration
+tsbridge_enable="YES"
+
+# Optional: Custom configuration file location
+tsbridge_config="/usr/local/etc/tsbridge/config.toml"
+
+# Optional: Run as different user/group
+tsbridge_user="tsbridge"
+tsbridge_group="tsbridge"
+
+# Optional: Additional command line flags
+tsbridge_flags=""
+
+# Optional: Environment variables
+tsbridge_env="GOMAXPROCS=4"
+
+# Optional: Process limits (see limits(1))
+tsbridge_limits="-n 65535"  # Max file descriptors
+```
+
+### Service Commands
+
+```bash
+# Start the service
+service tsbridge start
+
+# Stop the service
+service tsbridge stop
+
+# Check service status
+service tsbridge status
+
+# Reload configuration (if supported by tsbridge)
+service tsbridge reload
+
+# Enable service to start at boot
+sysrc tsbridge_enable="YES"
+
+# Disable service from starting at boot
+sysrc tsbridge_enable="NO"
+```
+
+## Monitoring
+
+### View Logs
+
+```bash
+# Service logs
+tail -f /var/log/tsbridge/tsbridge.log
+
+# Or use newsyslog for log rotation
+```
+
+### Configure Log Rotation
+
+Add to `/etc/newsyslog.conf`:
+
+```
+# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
+/var/log/tsbridge/tsbridge.log  tsbridge:tsbridge  640  7     *    @T00  J
+```
+
+### Check Service Status
+
+```bash
+# Check if service is running
+service tsbridge status
+
+# Check process
+ps aux | grep tsbridge
+
+# Check network listeners
+sockstat -4 -6 | grep tsbridge
+```
+
+## Security Considerations
+
+### File Permissions
+
+Ensure proper permissions on sensitive files:
+
+```bash
+# Configuration files
+chmod 644 /usr/local/etc/tsbridge/config.toml
+chmod 600 /usr/local/etc/tsbridge/oauth_client_*
+
+# Directories
+chmod 750 /var/run/tsbridge
+chmod 750 /var/log/tsbridge
+chmod 750 /var/db/tsbridge
+```
+
+### Firewall Configuration
+
+If using `pf`, add rules to allow tsbridge traffic:
+
+```pf
+# /etc/pf.conf
+# Allow tsbridge metrics (if enabled)
+pass in quick on $int_if proto tcp to port 9100
+
+# Tailscale traffic is handled by tailscale itself
+```
+
+### Resource Limits
+
+The rc.d script sets appropriate file descriptor limits by default. Additional limits can be configured in `/etc/rc.conf`:
+
+```bash
+# Example: Set custom limits
+tsbridge_limits="-n 100000 -u 512"  # Max files: 100k, Max processes: 512
+```
+
+## Troubleshooting
+
+### Service Won't Start
+
+1. Check configuration syntax:
+
+   ```bash
+   /usr/local/bin/tsbridge -config /usr/local/etc/tsbridge/config.toml -validate
+   ```
+
+2. Check logs:
+
+   ```bash
+   tail -n 50 /var/log/tsbridge/tsbridge.log
+   ```
+
+3. Verify permissions:
+
+   ```bash
+   ls -la /usr/local/etc/tsbridge/
+   ls -la /var/run/tsbridge/
+   ls -la /var/log/tsbridge/
+   ```
+
+4. Run manually for debugging:
+   ```bash
+   su -m tsbridge -c '/usr/local/bin/tsbridge -config /usr/local/etc/tsbridge/config.toml -verbose'
+   ```
+
+### Common Issues
+
+1. **OAuth Authentication Fails**
+   - Verify OAuth credentials are correct
+   - Check file permissions on credential files
+   - Ensure tsbridge user can read the files
+
+2. **Port Already in Use**
+   - Check for conflicting services: `sockstat -4 -6 | grep :PORT`
+   - Adjust service configuration to use different ports
+
+3. **File Descriptor Limits**
+   - Increase limits in rc.conf: `tsbridge_limits="-n 100000"`
+   - Check system-wide limits: `sysctl kern.maxfiles`
+
+## Jail Deployment
+
+To run tsbridge in a FreeBSD jail:
+
+1. Create jail with network access
+2. Install tsbridge inside the jail
+3. Configure as normal, but ensure:
+   - Tailscale connectivity works from within the jail
+   - Backend services are accessible from the jail network
+
+Example jail configuration in `/etc/jail.conf`:
+
+```
+tsbridge {
+    host.hostname = tsbridge.local;
+    ip4.addr = "lo0|10.0.0.10/32";
+    ip6 = "new";
+    exec.start = "/bin/sh /etc/rc";
+    exec.stop = "/bin/sh /etc/rc.shutdown";
+    mount.devfs;
+    persist;
+}
+```
+
+## Maintenance
+
+### Updating tsbridge
+
+1. Download new binary
+2. Stop service: `service tsbridge stop`
+3. Replace binary: `install -m 755 tsbridge /usr/local/bin/`
+4. Start service: `service tsbridge start`
+
+### Backup
+
+Important files to backup:
+
+- `/usr/local/etc/tsbridge/` (configuration and credentials)
+- `/var/db/tsbridge/` (if persistent state is stored)

--- a/deployments/freebsd/config.example.toml
+++ b/deployments/freebsd/config.example.toml
@@ -1,0 +1,107 @@
+# Example tsbridge configuration for FreeBSD
+# Copy to /usr/local/etc/tsbridge/config.toml and customize
+
+# Tailscale authentication configuration (required)
+[tailscale]
+# OAuth authentication (recommended)
+# Store credentials in separate files for security
+oauth_client_id_file = "/usr/local/etc/tsbridge/oauth_client_id"
+oauth_client_secret_file = "/usr/local/etc/tsbridge/oauth_client_secret"
+
+# Alternative: Use environment variables
+# oauth_client_id_env = "TS_OAUTH_CLIENT_ID"
+# oauth_client_secret_env = "TS_OAUTH_CLIENT_SECRET"
+
+# Alternative: Use auth key (not recommended for production)
+# auth_key_file = "/usr/local/etc/tsbridge/auth_key"
+
+# State directory for TSNet data
+state_dir = "/var/db/tsbridge"
+
+# Default tags for all services (required when using OAuth)
+default_tags = ["tag:server", "tag:tsbridge"]
+
+# Global defaults for all services (optional)
+[global]
+# Timeouts
+read_header_timeout = "10s"
+write_timeout = "30s"
+idle_timeout = "120s"
+shutdown_timeout = "15s"
+
+# Enable access logging
+access_log = true
+
+# Prometheus metrics endpoint
+metrics_addr = ":9100"
+
+# Security settings
+max_request_body_size = "10MB"
+
+# Whois timeout for Tailscale identity lookups
+whois_timeout = "1s"
+
+# Example services
+# Each service becomes accessible at https://<name>.<tailnet-name>.ts.net
+
+# Simple web application
+[[services]]
+name = "wiki"
+backend_addr = "127.0.0.1:8080"
+whois_enabled = true  # Inject Tailscale identity headers
+
+# API service with custom timeouts
+[[services]]
+name = "api"
+backend_addr = "127.0.0.1:3000"
+tags = ["tag:api"]  # Additional tags for this service
+write_timeout = "60s"  # Override global timeout
+max_request_body_size = "50MB"  # Override global limit
+
+# Add custom headers
+downstream_headers = { "X-Frame-Options" = "DENY", "X-Content-Type-Options" = "nosniff" }
+upstream_headers = { "X-Forwarded-By" = "tsbridge" }
+
+# Internal dashboard
+[[services]]
+name = "dashboard"
+backend_addr = "127.0.0.1:4000"
+whois_enabled = false  # Don't inject identity headers
+
+# Streaming service (disable timeouts for long-lived connections)
+[[services]]
+name = "stream"
+backend_addr = "127.0.0.1:8888"
+write_timeout = "0s"  # Disable timeout for streaming
+flush_interval = "-1ms"  # Immediate flushing for real-time data
+
+# Unix socket example (useful for local services)
+[[services]]
+name = "pgadmin"
+backend_addr = "unix:///var/run/pgadmin/pgadmin.sock"
+
+# Service with all options
+[[services]]
+name = "advanced"
+backend_addr = "10.0.0.5:8080"
+tags = ["tag:internal", "tag:admin"]
+whois_enabled = true
+
+# Override all timeouts
+read_header_timeout = "5s"
+write_timeout = "120s"
+idle_timeout = "300s"
+
+# Security settings
+max_request_body_size = "100MB"
+trusted_proxies = ["10.0.0.0/8", "172.16.0.0/12"]
+
+# Headers
+downstream_headers = { 
+    "Strict-Transport-Security" = "max-age=31536000; includeSubDomains",
+    "X-Frame-Options" = "SAMEORIGIN"
+}
+upstream_headers = {
+    "X-Real-IP" = "$remote_addr",
+    "X-Service-Name" = "advanced"
+}

--- a/deployments/freebsd/tsbridge
+++ b/deployments/freebsd/tsbridge
@@ -1,0 +1,155 @@
+#!/bin/sh
+
+# PROVIDE: tsbridge
+# REQUIRE: DAEMON NETWORKING
+# BEFORE: LOGIN
+# KEYWORD: shutdown
+
+# Add the following lines to /etc/rc.conf to enable tsbridge:
+#
+# tsbridge_enable (bool):       Set to "NO" by default.
+#                               Set it to "YES" to enable tsbridge.
+# tsbridge_config (path):       Set to "/usr/local/etc/tsbridge/config.toml" by default.
+#                               Path to the configuration file.
+# tsbridge_user (str):          Set to "tsbridge" by default.
+#                               User to run tsbridge as.
+# tsbridge_group (str):         Set to "tsbridge" by default.
+#                               Group to run tsbridge as.
+# tsbridge_flags (str):         Set to "" by default.
+#                               Extra flags passed to tsbridge.
+# tsbridge_env (str):           Set to "" by default.
+#                               Environment variables for tsbridge.
+# tsbridge_limits (str):        Set to "" by default.
+#                               Process limits (see limits(1)).
+
+. /etc/rc.subr
+
+name="tsbridge"
+rcvar="${name}_enable"
+
+# Default values
+: ${tsbridge_enable:="NO"}
+: ${tsbridge_config:="/usr/local/etc/tsbridge/config.toml"}
+: ${tsbridge_user:="tsbridge"}
+: ${tsbridge_group:="tsbridge"}
+: ${tsbridge_flags:=""}
+: ${tsbridge_env:=""}
+: ${tsbridge_limits:=""}
+
+# Paths
+pidfile="/var/run/${name}/${name}.pid"
+logfile="/var/log/${name}/${name}.log"
+command="/usr/local/bin/tsbridge"
+command_args="-config ${tsbridge_config} ${tsbridge_flags}"
+
+# Setup
+start_precmd="${name}_precmd"
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+status_cmd="${name}_status"
+reload_cmd="${name}_reload"
+extra_commands="reload"
+
+tsbridge_precmd()
+{
+    # Create required directories
+    local dirs="/var/run/${name} /var/log/${name} /var/db/${name}"
+    for dir in ${dirs}; do
+        if [ ! -d "${dir}" ]; then
+            install -d -o ${tsbridge_user} -g ${tsbridge_group} -m 750 "${dir}"
+        fi
+    done
+
+    # Check for configuration file
+    if [ ! -f "${tsbridge_config}" ]; then
+        err 1 "Configuration file ${tsbridge_config} not found"
+    fi
+
+    # Set file descriptor limits
+    if [ -n "${tsbridge_limits}" ]; then
+        eval `/usr/bin/limits ${tsbridge_limits} /usr/bin/env`
+    fi
+
+    # Set default file descriptor limit if not specified
+    ulimit -n 65535 2>/dev/null || true
+}
+
+tsbridge_start()
+{
+    echo "Starting ${name}."
+    
+    # Prepare environment
+    local env_cmd=""
+    if [ -n "${tsbridge_env}" ]; then
+        env_cmd="/usr/bin/env ${tsbridge_env}"
+    fi
+
+    # Start the daemon
+    /usr/sbin/daemon -c -f -p ${pidfile} -u ${tsbridge_user} \
+        -o ${logfile} \
+        ${env_cmd} ${command} ${command_args}
+}
+
+tsbridge_stop()
+{
+    echo "Stopping ${name}."
+    
+    if [ -f "${pidfile}" ]; then
+        local pid=$(cat ${pidfile})
+        if kill -0 ${pid} 2>/dev/null; then
+            # Send SIGTERM and wait for graceful shutdown
+            kill -TERM ${pid}
+            
+            # Wait up to 30 seconds for process to exit
+            local count=0
+            while kill -0 ${pid} 2>/dev/null && [ ${count} -lt 30 ]; do
+                sleep 1
+                count=$((count + 1))
+            done
+            
+            # Force kill if still running
+            if kill -0 ${pid} 2>/dev/null; then
+                echo "Timeout waiting for ${name} to stop, forcing shutdown."
+                kill -KILL ${pid}
+            fi
+        fi
+        rm -f ${pidfile}
+    fi
+}
+
+tsbridge_status()
+{
+    if [ -f "${pidfile}" ]; then
+        local pid=$(cat ${pidfile})
+        if kill -0 ${pid} 2>/dev/null; then
+            echo "${name} is running as pid ${pid}."
+            return 0
+        else
+            echo "${name} is not running (stale pidfile)."
+            rm -f ${pidfile}
+            return 1
+        fi
+    else
+        echo "${name} is not running."
+        return 1
+    fi
+}
+
+tsbridge_reload()
+{
+    echo "Reloading ${name} configuration."
+    
+    if [ -f "${pidfile}" ]; then
+        local pid=$(cat ${pidfile})
+        if kill -0 ${pid} 2>/dev/null; then
+            kill -HUP ${pid}
+        else
+            err 1 "${name} is not running"
+        fi
+    else
+        err 1 "${name} is not running"
+    fi
+}
+
+load_rc_config ${name}
+run_rc_command "$1"


### PR DESCRIPTION
- Add FreeBSD rc.d service script with proper daemon management
- Update .goreleaser.yaml to build FreeBSD binaries (amd64/arm64)
- Create comprehensive FreeBSD deployment documentation
- Add proper example configuration file with correct TOML structure
- Support for jails, resource limits, and log rotation
- Follow FreeBSD conventions for service management and file locations