### PR TITLE
feat: add retry logic with exponential backoff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/adrg/xdg v0.5.3
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/docker/docker v28.3.1+incompatible
 	github.com/go-viper/mapstructure/v2 v2.3.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -153,3 +153,27 @@ const (
 	// TsnetServerStartTimeout is the timeout for starting a tsnet server.
 	TsnetServerStartTimeout = 5 * time.Second
 )
+
+// Retry configuration constants.
+const (
+	// RetryInitialInterval is the initial interval between retry attempts.
+	RetryInitialInterval = 100 * time.Millisecond
+
+	// RetryMaxInterval is the maximum interval between retry attempts.
+	RetryMaxInterval = 2 * time.Second
+
+	// RetryMaxElapsedTime is the maximum total time for all retry attempts.
+	RetryMaxElapsedTime = 10 * time.Second
+
+	// RetryMultiplier is the multiplier for exponential backoff.
+	RetryMultiplier = 2.0
+
+	// RetryRandomizationFactor is the randomization factor for exponential backoff.
+	RetryRandomizationFactor = 0.1
+
+	// RetryMaxAttempts is the maximum number of retry attempts (2 retries = 3 total attempts).
+	RetryMaxAttempts = 2
+
+	// RetryMinTestDelay is the minimum expected delay for testing retry behavior.
+	RetryMinTestDelay = 50 * time.Millisecond
+)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -34,9 +34,10 @@ const (
 
 // Error is the standard error type with classification
 type Error struct {
-	Type    ErrorType
-	Message string
-	Err     error
+	Type           ErrorType
+	Message        string
+	Err            error
+	HTTPStatusCode int // Optional HTTP status code for network errors
 }
 
 // Error implements the error interface
@@ -70,6 +71,15 @@ func NewNetworkError(message string) error {
 	return &Error{
 		Type:    ErrTypeNetwork,
 		Message: message,
+	}
+}
+
+// NewNetworkErrorWithStatus creates a new network error with HTTP status code
+func NewNetworkErrorWithStatus(message string, statusCode int) error {
+	return &Error{
+		Type:           ErrTypeNetwork,
+		Message:        message,
+		HTTPStatusCode: statusCode,
 	}
 }
 
@@ -112,6 +122,16 @@ func WrapNetwork(err error, message string) error {
 		Type:    ErrTypeNetwork,
 		Message: message,
 		Err:     err,
+	}
+}
+
+// WrapNetworkWithStatus wraps an error as a network error with HTTP status code
+func WrapNetworkWithStatus(err error, message string, statusCode int) error {
+	return &Error{
+		Type:           ErrTypeNetwork,
+		Message:        message,
+		Err:            err,
+		HTTPStatusCode: statusCode,
 	}
 }
 

--- a/internal/middleware/whois.go
+++ b/internal/middleware/whois.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/jtdowney/tsbridge/internal/constants"
 	"tailscale.com/client/tailscale/apitype"
 )
 
@@ -47,14 +48,14 @@ func Whois(client WhoisClient, enabled bool, timeout time.Duration, cacheSize in
 func performWhoisWithRetryLogic(client WhoisClient, timeout time.Duration, r *http.Request) (*apitype.WhoIsResponse, error) {
 	// Configure exponential backoff with attempt limit
 	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = 100 * time.Millisecond
-	b.MaxInterval = 2 * time.Second
-	b.MaxElapsedTime = 10 * time.Second
-	b.Multiplier = 2.0
-	b.RandomizationFactor = 0.1
+	b.InitialInterval = constants.RetryInitialInterval
+	b.MaxInterval = constants.RetryMaxInterval
+	b.MaxElapsedTime = constants.RetryMaxElapsedTime
+	b.Multiplier = constants.RetryMultiplier
+	b.RandomizationFactor = constants.RetryRandomizationFactor
 
 	// Limit to 3 attempts using WithMaxRetries
-	backoffWithRetries := backoff.WithMaxRetries(b, 2) // 2 retries = 3 total attempts
+	backoffWithRetries := backoff.WithMaxRetries(b, constants.RetryMaxAttempts) // 2 retries = 3 total attempts
 
 	// Use context-aware backoff
 	ctxBackoff := backoff.WithContext(backoffWithRetries, r.Context())

--- a/internal/middleware/whois_test.go
+++ b/internal/middleware/whois_test.go
@@ -591,7 +591,7 @@ func TestWhoisRetryBehavior(t *testing.T) {
 
 					// Fail for the first N calls, then succeed
 					if callCount <= tt.failureCount {
-						return nil, errors.New("temporary failure")
+						return nil, errors.New("connection refused")
 					}
 
 					// Success response

--- a/internal/middleware/whois_test.go
+++ b/internal/middleware/whois_test.go
@@ -10,6 +10,7 @@ import (
 
 	"net/netip"
 
+	"github.com/jtdowney/tsbridge/internal/constants"
 	"github.com/stretchr/testify/assert"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
@@ -631,7 +632,7 @@ func TestWhoisRetryBehavior(t *testing.T) {
 
 			// Verify retry timing (should have delays for retries)
 			if tt.expectedCalls > 1 {
-				minExpectedDuration := time.Duration(tt.expectedCalls-1) * 50 * time.Millisecond
+				minExpectedDuration := time.Duration(tt.expectedCalls-1) * constants.RetryMinTestDelay
 				assert.GreaterOrEqual(t, duration, minExpectedDuration)
 			}
 		})

--- a/internal/middleware/whois_test.go
+++ b/internal/middleware/whois_test.go
@@ -10,6 +10,7 @@ import (
 
 	"net/netip"
 
+	"github.com/stretchr/testify/assert"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
 )
@@ -543,6 +544,95 @@ func TestWhois_HandlesPartialResponse(t *testing.T) {
 						t.Errorf("Header %s should not be set, but got %q", header, val)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestWhoisRetryBehavior(t *testing.T) {
+	tests := []struct {
+		name          string
+		failureCount  int
+		expectedCalls int
+		shouldSucceed bool
+		timeout       time.Duration
+	}{
+		{
+			name:          "succeeds immediately",
+			failureCount:  0,
+			expectedCalls: 1,
+			shouldSucceed: true,
+			timeout:       1 * time.Second,
+		},
+		{
+			name:          "succeeds after 2 failures",
+			failureCount:  2,
+			expectedCalls: 3,
+			shouldSucceed: true,
+			timeout:       5 * time.Second, // Longer timeout for retries
+		},
+		{
+			name:          "fails after max retries",
+			failureCount:  5,
+			expectedCalls: 3, // Default max attempts
+			shouldSucceed: false,
+			timeout:       5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callCount := 0
+
+			whoisClient := &MockWhoisClient{
+				WhoIsFunc: func(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
+					callCount++
+
+					// Fail for the first N calls, then succeed
+					if callCount <= tt.failureCount {
+						return nil, errors.New("temporary failure")
+					}
+
+					// Success response
+					return &apitype.WhoIsResponse{
+						UserProfile: &tailcfg.UserProfile{
+							LoginName:   "user@example.com",
+							DisplayName: "Test User",
+						},
+					}, nil
+				},
+			}
+
+			nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Use whois middleware (now includes retry)
+			middleware := Whois(whoisClient, true, tt.timeout, 0, 0)
+			handler := middleware(nextHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.RemoteAddr = "100.64.1.2:12345"
+			w := httptest.NewRecorder()
+
+			start := time.Now()
+			handler.ServeHTTP(w, req)
+			duration := time.Since(start)
+
+			// Verify expected number of calls
+			assert.Equal(t, tt.expectedCalls, callCount)
+
+			// Verify headers are set on success
+			if tt.shouldSucceed {
+				assert.Equal(t, "user@example.com", req.Header.Get("X-Tailscale-User"))
+			} else {
+				assert.Empty(t, req.Header.Get("X-Tailscale-User"))
+			}
+
+			// Verify retry timing (should have delays for retries)
+			if tt.expectedCalls > 1 {
+				minExpectedDuration := time.Duration(tt.expectedCalls-1) * 50 * time.Millisecond
+				assert.GreaterOrEqual(t, duration, minExpectedDuration)
 			}
 		})
 	}

--- a/internal/tailscale/oauth.go
+++ b/internal/tailscale/oauth.go
@@ -55,14 +55,14 @@ type authKeyResponse struct {
 func generateAuthKeyWithOAuth(oauthConfig *oauth2.Config, apiBaseURL string, tags []string, ephemeral bool) (string, error) {
 	// Configure exponential backoff with attempt limit
 	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = 100 * time.Millisecond
-	b.MaxInterval = 2 * time.Second
-	b.MaxElapsedTime = 10 * time.Second
-	b.Multiplier = 2.0
-	b.RandomizationFactor = 0.1
+	b.InitialInterval = constants.RetryInitialInterval
+	b.MaxInterval = constants.RetryMaxInterval
+	b.MaxElapsedTime = constants.RetryMaxElapsedTime
+	b.Multiplier = constants.RetryMultiplier
+	b.RandomizationFactor = constants.RetryRandomizationFactor
 
 	// Limit to 3 attempts using WithMaxRetries
-	backoffWithRetries := backoff.WithMaxRetries(b, 2) // 2 retries = 3 total attempts
+	backoffWithRetries := backoff.WithMaxRetries(b, constants.RetryMaxAttempts) // 2 retries = 3 total attempts
 
 	var authKey string
 	operation := func() error {

--- a/internal/tailscale/oauth_test.go
+++ b/internal/tailscale/oauth_test.go
@@ -713,7 +713,7 @@ func TestOAuthRetryBehavior(t *testing.T) {
 
 			// Verify retry timing (should have delays for retries)
 			if tt.expectedCalls > 1 {
-				minExpectedDuration := time.Duration(tt.expectedCalls-1) * 50 * time.Millisecond // Minimum delay
+				minExpectedDuration := time.Duration(tt.expectedCalls-1) * constants.RetryMinTestDelay
 				assert.GreaterOrEqual(t, duration, minExpectedDuration)
 			}
 		})

--- a/internal/tailscale/oauth_test.go
+++ b/internal/tailscale/oauth_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/jtdowney/tsbridge/internal/config"
 	"github.com/jtdowney/tsbridge/internal/constants"
 	"github.com/jtdowney/tsbridge/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
 
@@ -613,5 +615,107 @@ func TestAuthKeyGenerationLogging(t *testing.T) {
 	}
 	if !strings.Contains(logOutput, `service=test-service`) {
 		t.Error("expected service name in log")
+	}
+}
+
+func TestOAuthRetryBehavior(t *testing.T) {
+	tests := []struct {
+		name          string
+		failureCount  int
+		expectedCalls int
+		shouldSucceed bool
+	}{
+		{
+			name:          "succeeds immediately",
+			failureCount:  0,
+			expectedCalls: 1,
+			shouldSucceed: true,
+		},
+		{
+			name:          "succeeds after 2 failures",
+			failureCount:  2,
+			expectedCalls: 3,
+			shouldSucceed: true,
+		},
+		{
+			name:          "fails after max retries",
+			failureCount:  5,
+			expectedCalls: 3, // Default max attempts
+			shouldSucceed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenCallCount := 0
+			apiCallCount := 0
+
+			// Mock OAuth2 token endpoint (always succeeds)
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tokenCallCount++
+				w.Header().Set("Content-Type", "application/json")
+				token := map[string]interface{}{
+					"access_token": "mock-access-token",
+					"token_type":   "Bearer",
+					"expires_in":   3600,
+				}
+				_ = json.NewEncoder(w).Encode(token)
+			}))
+			defer tokenServer.Close()
+
+			// Mock Tailscale API endpoint (fails then succeeds)
+			apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				apiCallCount++
+
+				// Fail for the first N calls, then succeed
+				if apiCallCount <= tt.failureCount {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(`{"error": "temporary failure"}`))
+					return
+				}
+
+				// Success response
+				w.Header().Set("Content-Type", "application/json")
+				response := map[string]interface{}{
+					"key":     "tskey-auth-mock123",
+					"created": time.Now().Format(time.RFC3339),
+				}
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer apiServer.Close()
+
+			// Configure OAuth
+			oauthConfig := &oauth2.Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				Endpoint: oauth2.Endpoint{
+					TokenURL: tokenServer.URL + "/oauth/token",
+				},
+			}
+
+			// Attempt to generate auth key with retry
+			start := time.Now()
+			authKey, err := generateAuthKeyWithOAuth(oauthConfig, apiServer.URL, []string{"tag:test"}, false)
+			duration := time.Since(start)
+
+			// Verify results
+			if tt.shouldSucceed {
+				require.NoError(t, err)
+				assert.Equal(t, "tskey-auth-mock123", authKey)
+			} else {
+				require.Error(t, err)
+				// cenkalti/backoff returns the last error encountered, not a "max attempts" message
+				assert.Contains(t, err.Error(), "status 500")
+			}
+
+			// Verify expected number of API calls
+			assert.Equal(t, tt.expectedCalls, apiCallCount)
+
+			// Verify retry timing (should have delays for retries)
+			if tt.expectedCalls > 1 {
+				minExpectedDuration := time.Duration(tt.expectedCalls-1) * 50 * time.Millisecond // Minimum delay
+				assert.GreaterOrEqual(t, duration, minExpectedDuration)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Add retry support to OAuth operations and whois lookups
- Use cenkalti/backoff library for reliable retry behavior
- Consolidate duplicate OAuth and whois function variants
- Remove proxy retry logic per requirements
- Configure maximum 3 attempts with exponential backoff

Improves reliability under network instability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retry with exponential backoff for Whois lookups and OAuth-based auth key generation, improving reliability during network issues.
  * Introduced configurable retry parameters for fine-tuned control over retry behavior.
  * Enhanced error handling to include HTTP status codes for network errors.

* **Bug Fixes**
  * Improved classification of retryable errors for network and HTTP failures.

* **Tests**
  * Added comprehensive tests to verify retry logic and error handling for both Whois and OAuth flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->