### PR TITLE
feat: add STATE_DIRECTORY environment variable support

### DIFF
--- a/deployments/systemd/README.md
+++ b/deployments/systemd/README.md
@@ -30,19 +30,15 @@ sudo useradd --system --shell /bin/false --home-dir /var/lib/tsbridge --create-h
 ### 2. Install the binary
 
 ```bash
-# Copy the tsbridge binary to system location
-sudo cp tsbridge /usr/local/bin/
-sudo chmod 755 /usr/local/bin/tsbridge
-sudo chown root:root /usr/local/bin/tsbridge
+# Install binary with appropriate permissions
+sudo install -o root -g root -m 755 tsbridge /usr/local/bin/
 ```
 
 ### 3. Create configuration directory
 
 ```bash
-# Create config directory
-sudo mkdir -p /etc/tsbridge
-sudo chown tsbridge:tsbridge /etc/tsbridge
-sudo chmod 755 /etc/tsbridge
+# Create config directory with appropriate permissions
+sudo install -d -o tsbridge -g tsbridge -m 755 /etc/tsbridge
 ```
 
 **Note**: The state directory (`/var/lib/tsbridge`) is automatically created and managed by systemd using the `StateDirectory` directive in the service file. You don't need to create it manually.
@@ -50,24 +46,19 @@ sudo chmod 755 /etc/tsbridge
 ### 4. Install configuration files
 
 ```bash
-# Copy your TOML configuration
-sudo cp config.toml /etc/tsbridge/config.toml
-sudo chown tsbridge:tsbridge /etc/tsbridge/config.toml
-sudo chmod 640 /etc/tsbridge/config.toml
+# Install your TOML configuration
+sudo install -o tsbridge -g tsbridge -m 640 config.toml /etc/tsbridge/
 
-# Copy and edit environment file (optional)
-sudo cp tsbridge.env.example /etc/tsbridge/tsbridge.env
-sudo chown tsbridge:tsbridge /etc/tsbridge/tsbridge.env
-sudo chmod 600 /etc/tsbridge/tsbridge.env
+# Install and edit environment file (optional)
+sudo install -o tsbridge -g tsbridge -m 600 tsbridge.env.example /etc/tsbridge/tsbridge.env
 # Edit /etc/tsbridge/tsbridge.env with your OAuth credentials
 ```
 
 ### 5. Install systemd service
 
 ```bash
-# Copy service file
-sudo cp tsbridge.service /etc/systemd/system/
-sudo chmod 644 /etc/systemd/system/tsbridge.service
+# Install service file
+sudo install -m 644 tsbridge.service /etc/systemd/system/
 
 # Reload systemd
 sudo systemctl daemon-reload

--- a/deployments/systemd/README.md
+++ b/deployments/systemd/README.md
@@ -6,7 +6,17 @@ This directory contains systemd service files and related configuration for depl
 
 - `tsbridge.service` - The main systemd service unit file
 - `tsbridge.env.example` - Example environment file for sensitive configuration
-- `tsbridge.logrotate` - Logrotate configuration for log management
+
+## systemd State Directory Integration
+
+The service file uses systemd's `StateDirectory` directive, which provides several benefits:
+
+- **Automatic creation**: systemd creates `/var/lib/tsbridge` automatically with correct permissions
+- **Automatic cleanup**: The directory can be removed when the service is uninstalled
+- **Environment variable**: systemd sets `STATE_DIRECTORY=/var/lib/tsbridge` automatically
+- **Security**: The directory is only accessible by the tsbridge user
+
+tsbridge automatically detects and uses the `STATE_DIRECTORY` environment variable when available, requiring no additional configuration.
 
 ## Installation
 
@@ -26,24 +36,16 @@ sudo chmod 755 /usr/local/bin/tsbridge
 sudo chown root:root /usr/local/bin/tsbridge
 ```
 
-### 3. Create configuration directories
+### 3. Create configuration directory
 
 ```bash
 # Create config directory
 sudo mkdir -p /etc/tsbridge
 sudo chown tsbridge:tsbridge /etc/tsbridge
 sudo chmod 755 /etc/tsbridge
-
-# Create state directory (for Tailscale state)
-sudo mkdir -p /var/lib/tsbridge
-sudo chown tsbridge:tsbridge /var/lib/tsbridge
-sudo chmod 700 /var/lib/tsbridge
-
-# Create log directory
-sudo mkdir -p /var/log/tsbridge
-sudo chown tsbridge:tsbridge /var/log/tsbridge
-sudo chmod 755 /var/log/tsbridge
 ```
+
+**Note**: The state directory (`/var/lib/tsbridge`) is automatically created and managed by systemd using the `StateDirectory` directive in the service file. You don't need to create it manually.
 
 ### 4. Install configuration files
 
@@ -71,15 +73,7 @@ sudo chmod 644 /etc/systemd/system/tsbridge.service
 sudo systemctl daemon-reload
 ```
 
-### 6. Configure logrotate (optional)
-
-```bash
-# Install logrotate config
-sudo cp tsbridge.logrotate /etc/logrotate.d/tsbridge
-sudo chmod 644 /etc/logrotate.d/tsbridge
-```
-
-### 7. Validate configuration
+### 6. Validate configuration
 
 Before starting the service, validate your configuration:
 
@@ -88,7 +82,7 @@ Before starting the service, validate your configuration:
 sudo -u tsbridge /usr/local/bin/tsbridge -config /etc/tsbridge/config.toml -validate
 ```
 
-### 8. Start and enable the service
+### 7. Start and enable the service
 
 ```bash
 # Start the service

--- a/deployments/systemd/tsbridge.service
+++ b/deployments/systemd/tsbridge.service
@@ -30,8 +30,12 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 RemoveIPC=true
 
-# Allow writing to state directory and logs
-ReadWritePaths=/var/lib/tsbridge /var/log/tsbridge
+# State directory management (systemd will create and manage /var/lib/tsbridge)
+StateDirectory=tsbridge
+StateDirectoryMode=0750
+
+# Allow writing to state directory
+ReadWritePaths=/var/lib/tsbridge
 
 # Resource limits
 LimitNOFILE=65535


### PR DESCRIPTION
Add support for systemd's STATE_DIRECTORY environment variable to allow tsbridge to automatically use systemd-managed state directories. This enables better integration with systemd's StateDirectory feature.

Changes:
- Add state_dir_env configuration parameter for custom env var resolution
- Support STATE_DIRECTORY env var with colon-separated path handling
- Update state directory resolution priority order
- Update systemd service file to use StateDirectory directive
- Add comprehensive tests for all resolution scenarios

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the state directory path via a custom environment variable in the configuration.
  * Enhanced state directory resolution to prioritize explicit config, custom environment variable, systemd’s `STATE_DIRECTORY`, tsbridge-specific variable, and XDG defaults.

* **Documentation**
  * Updated documentation to clarify state directory resolution order and systemd integration.
  * Simplified installation steps by removing manual directory creation and logrotate configuration.
  * Added details on systemd’s automatic state directory management.

* **Bug Fixes**
  * Improved robustness and clarity in state directory handling, especially in systemd environments.

* **Tests**
  * Added comprehensive tests covering state directory resolution logic and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->