### PR TITLE
fix: implement TSBRIDGE_DEBUG environment variable support

### DIFF
--- a/cmd/tsbridge/main.go
+++ b/cmd/tsbridge/main.go
@@ -80,6 +80,11 @@ func parseCLIArgs(args []string) (*cliArgs, error) {
 	// Set the global flag.Usage to match
 	flag.Usage = usage
 
+	// Check TSBRIDGE_DEBUG environment variable if verbose not explicitly set
+	if !result.verbose && os.Getenv("TSBRIDGE_DEBUG") != "" {
+		result.verbose = true
+	}
+
 	return result, nil
 }
 

--- a/cmd/tsbridge/main_test.go
+++ b/cmd/tsbridge/main_test.go
@@ -816,6 +816,63 @@ func TestParseCLIArgs(t *testing.T) {
 	}
 }
 
+// TestParseCLIArgsWithTSBRIDGEDEBUG tests that TSBRIDGE_DEBUG environment variable enables verbose mode
+func TestParseCLIArgsWithTSBRIDGEDEBUG(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		envValue  string
+		wantDebug bool
+	}{
+		{
+			name:      "TSBRIDGE_DEBUG not set",
+			args:      []string{},
+			envValue:  "",
+			wantDebug: false,
+		},
+		{
+			name:      "TSBRIDGE_DEBUG set to 1",
+			args:      []string{},
+			envValue:  "1",
+			wantDebug: true,
+		},
+		{
+			name:      "TSBRIDGE_DEBUG set to any value",
+			args:      []string{},
+			envValue:  "true",
+			wantDebug: true,
+		},
+		{
+			name:      "verbose flag overrides TSBRIDGE_DEBUG",
+			args:      []string{"-verbose"},
+			envValue:  "",
+			wantDebug: true,
+		},
+		{
+			name:      "verbose flag takes precedence when both set",
+			args:      []string{"-verbose"},
+			envValue:  "1",
+			wantDebug: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set or unset the environment variable
+			if tt.envValue != "" {
+				t.Setenv("TSBRIDGE_DEBUG", tt.envValue)
+			} else {
+				// Ensure it's not set
+				os.Unsetenv("TSBRIDGE_DEBUG")
+			}
+
+			got, err := parseCLIArgs(tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDebug, got.verbose, "verbose flag mismatch")
+		})
+	}
+}
+
 // TestRun tests the run function
 func TestRun(t *testing.T) {
 	// Save original version


### PR DESCRIPTION
The systemd documentation referenced TSBRIDGE_DEBUG but it was not actually implemented. This adds support for enabling verbose logging via the TSBRIDGE_DEBUG environment variable when set to any non-empty value. The -verbose CLI flag takes precedence if both are set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verbose logging is now automatically enabled when the TSBRIDGE_DEBUG environment variable is set, even if the verbose flag is not specified.

* **Tests**
  * Added tests to verify that verbose mode is enabled when TSBRIDGE_DEBUG is set and to confirm correct behavior when the verbose flag is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->