### PR TITLE
feat: add trace-level debug logging for tsnet authentication and startup

### DIFF
--- a/internal/tailscale/state.go
+++ b/internal/tailscale/state.go
@@ -1,6 +1,7 @@
 package tailscale
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -10,19 +11,71 @@ func hasExistingState(stateDir string, serviceName string) bool {
 	// Each service has its own subdirectory under the state directory
 	serviceStateDir := filepath.Join(stateDir, serviceName)
 
+	slog.Debug("checking for existing tsnet state",
+		"service", serviceName,
+		"state_dir", stateDir,
+		"service_state_dir", serviceStateDir,
+	)
+
 	// Check if the directory exists
 	info, err := os.Stat(serviceStateDir)
-	if err != nil || !info.IsDir() {
+	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Debug("state directory does not exist",
+				"service", serviceName,
+				"service_state_dir", serviceStateDir,
+			)
+		} else {
+			slog.Debug("error checking state directory",
+				"service", serviceName,
+				"service_state_dir", serviceStateDir,
+				"error", err,
+			)
+		}
 		return false
 	}
+
+	if !info.IsDir() {
+		slog.Debug("state path exists but is not a directory",
+			"service", serviceName,
+			"service_state_dir", serviceStateDir,
+		)
+		return false
+	}
+
+	slog.Debug("state directory exists",
+		"service", serviceName,
+		"service_state_dir", serviceStateDir,
+	)
 
 	// Check for key state files that indicate an initialized node
 	// tsnet stores various state files, but the key ones are:
 	// - tailscaled.state: The main state file
 	// - tailscaled.log.conf: Logging configuration
 	stateFile := filepath.Join(serviceStateDir, "tailscaled.state")
+
+	slog.Debug("checking for state file",
+		"service", serviceName,
+		"state_file", stateFile,
+	)
+
 	if _, err := os.Stat(stateFile); err == nil {
+		slog.Debug("existing state file found",
+			"service", serviceName,
+			"state_file", stateFile,
+		)
 		return true
+	} else if os.IsNotExist(err) {
+		slog.Debug("state file does not exist",
+			"service", serviceName,
+			"state_file", stateFile,
+		)
+	} else {
+		slog.Debug("error checking state file",
+			"service", serviceName,
+			"state_file", stateFile,
+			"error", err,
+		)
 	}
 
 	return false

--- a/internal/tsnet/interfaces.go
+++ b/internal/tsnet/interfaces.go
@@ -3,7 +3,9 @@ package tsnet
 
 import (
 	"context"
+	"log/slog"
 	"net"
+	"time"
 
 	"tailscale.com/client/local"
 	"tailscale.com/client/tailscale/apitype"
@@ -67,17 +69,86 @@ func NewRealTSNetServer() *RealTSNetServer {
 
 // Listen implements TSNetServer.
 func (s *RealTSNetServer) Listen(network, addr string) (net.Listener, error) {
-	return s.Server.Listen(network, addr)
+	start := time.Now()
+	slog.Debug("tsnet Listen() called",
+		"hostname", s.Hostname,
+		"network", network,
+		"addr", addr,
+	)
+
+	listener, err := s.Server.Listen(network, addr)
+
+	if err != nil {
+		slog.Debug("tsnet Listen() failed",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+			"error", err,
+		)
+	} else {
+		slog.Debug("tsnet Listen() succeeded",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+			"listener_addr", listener.Addr(),
+		)
+	}
+
+	return listener, err
 }
 
 // ListenTLS implements TSNetServer.
 func (s *RealTSNetServer) ListenTLS(network, addr string) (net.Listener, error) {
-	return s.Server.ListenTLS(network, addr)
+	start := time.Now()
+	slog.Debug("tsnet ListenTLS() called",
+		"hostname", s.Hostname,
+		"network", network,
+		"addr", addr,
+	)
+
+	listener, err := s.Server.ListenTLS(network, addr)
+
+	if err != nil {
+		slog.Debug("tsnet ListenTLS() failed",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+			"error", err,
+		)
+	} else {
+		slog.Debug("tsnet ListenTLS() succeeded",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+			"listener_addr", listener.Addr(),
+		)
+	}
+
+	return listener, err
 }
 
 // ListenFunnel implements TSNetServer.
 func (s *RealTSNetServer) ListenFunnel(network, addr string) (net.Listener, error) {
-	return s.Server.ListenFunnel(network, addr)
+	start := time.Now()
+	slog.Debug("tsnet ListenFunnel() called",
+		"hostname", s.Hostname,
+		"network", network,
+		"addr", addr,
+	)
+
+	listener, err := s.Server.ListenFunnel(network, addr)
+
+	if err != nil {
+		slog.Debug("tsnet ListenFunnel() failed",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+			"error", err,
+		)
+	} else {
+		slog.Debug("tsnet ListenFunnel() succeeded",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+			"listener_addr", listener.Addr(),
+		)
+	}
+
+	return listener, err
 }
 
 // Close implements TSNetServer.
@@ -87,7 +158,30 @@ func (s *RealTSNetServer) Close() error {
 
 // Start implements TSNetServer.
 func (s *RealTSNetServer) Start() error {
-	return s.Server.Start()
+	start := time.Now()
+	slog.Debug("tsnet server Start() called",
+		"hostname", s.Hostname,
+		"ephemeral", s.Ephemeral,
+		"dir", s.Dir,
+		"has_auth_key", s.AuthKey != "",
+	)
+
+	err := s.Server.Start()
+
+	if err != nil {
+		slog.Debug("tsnet server Start() failed",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+			"error", err,
+		)
+	} else {
+		slog.Debug("tsnet server Start() succeeded",
+			"hostname", s.Hostname,
+			"duration", time.Since(start),
+		)
+	}
+
+	return err
 }
 
 // LocalClient implements TSNetServer.


### PR DESCRIPTION
Add comprehensive debug logging to help diagnose issue #52 where services fail to re-register with proper tags after system restart when using OAuth.

The logging covers:
- OAuth authentication flow with retry attempts and timing
- Service startup sequence including state directory resolution
- TSNet server operations (Start, Listen, ListenTLS, ListenFunnel)
- State file existence checks to detect when auth keys are needed
- Service registry operations with timing for each phase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed debug-level logging and timing information throughout the service startup, OAuth authentication, state checking, and network listener setup processes. This provides enhanced visibility into system operations and performance.

* **Style**
  * Improved diagnostic output for easier tracing and troubleshooting of service behavior during startup and authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->