### PR TITLE
ci: capture GoReleaser artifacts on PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           VERSION=$(git describe --tags --always --dirty)
           go build -ldflags "-X main.version=$VERSION" -v ./cmd/...
 
-  docker:
+  build-pr:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'pull_request'
@@ -65,6 +65,16 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload GoReleaser Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: goreleaser-artifacts
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          retention-days: 7
 
       - name: Push PR Docker Images
         run: |


### PR DESCRIPTION
- Add artifact upload step to capture binaries and checksums
- Rename 'docker' job to 'build-pr' to reflect broader purpose
- Artifacts are retained for 7 days for PR testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the name of the pull request build job in the workflow.
  * Added automatic upload of build artifacts for pull requests, making them available for download for 7 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->