### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/jtdowney/tsbridge/security/code-scanning/1](https://github.com/jtdowney/tsbridge/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since this is a linting job, it only needs read access to the repository contents. We will set `contents: read` at the job level to explicitly limit the permissions of the `GITHUB_TOKEN`. This change ensures that the workflow operates with the minimum required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the linting workflow to improve security settings for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->