### PR TITLE
fix: add missing state_dir_env to Docker provider

### DIFF
--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -70,6 +70,7 @@ labels:
 
   # State directory
   - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+  - "tsbridge.tailscale.state_dir_env=<env_var>"
 
   # Default tags for all services (comma-separated)
   - "tsbridge.tailscale.default_tags=tag:tsbridge,tag:proxy"

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -208,6 +208,7 @@ func (p *Provider) parseGlobalConfig(container *container.Summary, cfg *config.C
 		AuthKeyEnv:            parser.getString("tailscale.auth_key_env"),
 		AuthKeyFile:           parser.getString("tailscale.auth_key_file"),
 		StateDir:              parser.getString("tailscale.state_dir"),
+		StateDirEnv:           parser.getString("tailscale.state_dir_env"),
 		DefaultTags:           parser.getStringSlice("tailscale.default_tags", ","),
 	}
 

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -628,6 +628,26 @@ func TestConfigParityBetweenTOMLAndDocker(t *testing.T) {
 				field.Name, mapstructureTag)
 		}
 	})
+
+	t.Run("Tailscale config fields", func(t *testing.T) {
+		// Get all fields from the Tailscale struct
+		tailscaleType := reflect.TypeOf(config.Tailscale{})
+		dockerParsedFields := getDockerParsedTailscaleFields()
+
+		for i := 0; i < tailscaleType.NumField(); i++ {
+			field := tailscaleType.Field(i)
+			mapstructureTag := field.Tag.Get("mapstructure")
+			if mapstructureTag == "" {
+				continue // Skip fields without mapstructure tag
+			}
+
+			// Check if this field is parsed in Docker
+			dockerKey := "tailscale." + mapstructureTag
+			assert.Contains(t, dockerParsedFields, dockerKey,
+				"Field %s (%s) is in config.Tailscale but not parsed in Docker labels",
+				field.Name, mapstructureTag)
+		}
+	})
 }
 
 // getDockerParsedGlobalFields returns all global.* fields that are parsed in Docker
@@ -677,5 +697,24 @@ func getDockerParsedServiceFields() map[string]bool {
 		"service.remove_downstream":       true,
 		"service.tags":                    true,
 		"service.max_request_body_size":   true,
+	}
+}
+
+// getDockerParsedTailscaleFields returns all tailscale.* fields that are parsed in Docker
+// This list must be kept in sync with parseGlobalConfig() in labels.go
+func getDockerParsedTailscaleFields() map[string]bool {
+	return map[string]bool{
+		"tailscale.oauth_client_id":          true,
+		"tailscale.oauth_client_id_env":      true,
+		"tailscale.oauth_client_id_file":     true,
+		"tailscale.oauth_client_secret":      true,
+		"tailscale.oauth_client_secret_env":  true,
+		"tailscale.oauth_client_secret_file": true,
+		"tailscale.auth_key":                 true,
+		"tailscale.auth_key_env":             true,
+		"tailscale.auth_key_file":            true,
+		"tailscale.state_dir":                true,
+		"tailscale.state_dir_env":            true,
+		"tailscale.default_tags":             true,
 	}
 }


### PR DESCRIPTION
The state_dir_env field was present in the TOML configuration but was not being parsed by the Docker provider. This adds support for the field in:
- Docker label parsing in parseGlobalConfig()
- Test coverage in TestConfigParityBetweenTOMLAndDocker
- Documentation in docker-labels.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include a new Docker label option for specifying the Tailscale state directory via an environment variable.
* **Bug Fixes**
  * Ensured Docker label parsing supports the new environment variable option for the Tailscale state directory.
* **Tests**
  * Added tests to verify that all Tailscale configuration fields are correctly mapped to Docker label keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->