### PR TITLE
fix: allow startup without OAuth/authkey for pre-registered services

### DIFF
--- a/cmd/tsbridge/main_test.go
+++ b/cmd/tsbridge/main_test.go
@@ -1019,8 +1019,8 @@ backend_addr = "localhost:8080"
 				require.NoError(t, err)
 				return configPath
 			},
-			wantErr: true,
-			errMsg:  "OAuth client ID must be provided",
+			wantErr:    false, // No longer an error - missing auth is allowed
+			wantOutput: []string{"configuration is valid"},
 		},
 	}
 
@@ -1069,13 +1069,17 @@ backend_addr = "localhost:8080"
 
 			// Check output
 			outputStr := string(output)
+			logStr := logBuf.String()
 			// For help, also check if it printed "Usage of tsbridge:" but without the full content
 			if tt.name == "help flag" && outputStr != "" {
 				// Help was printed, we're good
 				assert.Contains(t, outputStr, "Usage of tsbridge:")
 			} else {
 				for _, want := range tt.wantOutput {
-					assert.Contains(t, outputStr, want)
+					// Check both stdout and logs
+					if !strings.Contains(outputStr, want) && !strings.Contains(logStr, want) {
+						t.Errorf("expected output to contain %q, got stdout: %q, logs: %q", want, outputStr, logStr)
+					}
 				}
 			}
 		})

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -878,17 +878,17 @@ tags = ["tag:test"]
 
 			// Test validation
 			t.Run("Validation", func(t *testing.T) {
-				// Use missing_oauth fixture
+				// Use a fixture that has an actual validation error
 				fixtures := getTestFixtures()
-				var missingOAuthFixture TestFixture
+				var errorFixture TestFixture
 				for _, f := range fixtures {
-					if f.Name == "missing_oauth" {
-						missingOAuthFixture = f
+					if f.Name == "missing_backend_addr" {
+						errorFixture = f
 						break
 					}
 				}
 
-				content := missingOAuthFixture.Content
+				content := errorFixture.Content
 				provider, cleanup := tt.createProvider(t, content)
 				defer cleanup()
 

--- a/internal/tailscale/oauth_test.go
+++ b/internal/tailscale/oauth_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/jtdowney/tsbridge/internal/config"
 	"github.com/jtdowney/tsbridge/internal/constants"
-	"github.com/jtdowney/tsbridge/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -480,15 +479,12 @@ func TestOAuthEphemeralFlag(t *testing.T) {
 }
 
 func TestCredentialResolutionErrorTypes(t *testing.T) {
-	t.Run("no auth key or oauth returns config error", func(t *testing.T) {
+	t.Run("no auth key or oauth is now allowed", func(t *testing.T) {
 		cfg := config.Tailscale{}
 		_, err := NewServer(cfg)
 
-		if err == nil {
-			t.Fatal("expected error when no auth key or oauth provided")
-		}
-		if !errors.IsConfig(err) {
-			t.Errorf("expected config error, got %v", err)
+		if err != nil {
+			t.Fatalf("unexpected error when no auth key or oauth provided: %v", err)
 		}
 	})
 }

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -35,6 +35,15 @@ type Server struct {
 
 // NewServerWithFactory creates a new tailscale server instance with a custom TSNetServer factory
 func NewServerWithFactory(cfg config.Tailscale, factory tsnetpkg.TSNetServerFactory) (*Server, error) {
+	// Validate OAuth credentials if provided - both must be present or neither
+	if (cfg.OAuthClientID != "" && cfg.OAuthClientSecret == "") ||
+		(cfg.OAuthClientID == "" && cfg.OAuthClientSecret != "") {
+		if cfg.OAuthClientID == "" {
+			return nil, tserrors.NewConfigError("OAuth client secret provided without client ID")
+		}
+		return nil, tserrors.NewConfigError("OAuth client ID provided without client secret")
+	}
+
 	return &Server{
 		config:         cfg,
 		serviceServers: make(map[string]tsnetpkg.TSNetServer),

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -56,26 +56,23 @@ func TestNewServer(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "missing auth configuration",
+			name:    "missing auth configuration is now allowed",
 			cfg:     config.Tailscale{},
-			wantErr: true,
-			errMsg:  "either auth key or OAuth credentials",
+			wantErr: false,
 		},
 		{
-			name: "incomplete OAuth - missing secret",
+			name: "incomplete OAuth - missing secret is still allowed",
 			cfg: config.Tailscale{
 				OAuthClientID: "test-client-id",
 			},
-			wantErr: true,
-			errMsg:  "OAuth client secret is required",
+			wantErr: false,
 		},
 		{
-			name: "incomplete OAuth - missing ID",
+			name: "incomplete OAuth - missing ID is still allowed",
 			cfg: config.Tailscale{
 				OAuthClientSecret: config.RedactedString("test-client-secret"),
 			},
-			wantErr: true,
-			errMsg:  "OAuth client ID is required",
+			wantErr: false,
 		},
 	}
 
@@ -440,6 +437,155 @@ func TestListen_EphemeralServices(t *testing.T) {
 
 			// Verify ephemeral flag is always set correctly
 			assert.Equal(t, tt.svc.Ephemeral, mockServer.Ephemeral)
+		})
+	}
+}
+
+func TestPrepareServiceAuth(t *testing.T) {
+	// Create a mock OAuth server for tests that need OAuth
+	oauthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			token := map[string]interface{}{
+				"access_token": "mock-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}
+			_ = json.NewEncoder(w).Encode(token)
+		case "/api/v2/tailnet/-/keys":
+			w.Header().Set("Content-Type", "application/json")
+			key := map[string]interface{}{
+				"id":          "key123",
+				"key":         "tskey-test-generated",
+				"created":     "2023-01-01T00:00:00Z",
+				"expires":     "2023-01-02T00:00:00Z",
+				"description": "generated for test-service",
+			}
+			_ = json.NewEncoder(w).Encode(key)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer oauthServer.Close()
+
+	// Set test OAuth endpoint
+	t.Setenv("TSBRIDGE_OAUTH_ENDPOINT", oauthServer.URL)
+
+	tests := []struct {
+		name            string
+		cfg             config.Tailscale
+		svc             config.Service
+		setupStateDir   bool
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "ephemeral service with OAuth credentials",
+			cfg: config.Tailscale{
+				OAuthClientID:     "test-id",
+				OAuthClientSecret: config.RedactedString("test-secret"),
+			},
+			svc: config.Service{
+				Name:      "test-service",
+				Ephemeral: true,
+				Tags:      []string{"tag:test"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ephemeral service without credentials",
+			cfg:  config.Tailscale{},
+			svc: config.Service{
+				Name:      "test-service",
+				Ephemeral: true,
+			},
+			wantErr:         true,
+			wantErrContains: "needs authentication",
+		},
+		{
+			name: "non-ephemeral service with existing state",
+			cfg:  config.Tailscale{},
+			svc: config.Service{
+				Name: "test-service",
+			},
+			setupStateDir: true,
+			wantErr:       false,
+		},
+		{
+			name: "non-ephemeral service without existing state and without credentials",
+			cfg:  config.Tailscale{},
+			svc: config.Service{
+				Name: "test-service",
+			},
+			setupStateDir:   false,
+			wantErr:         true,
+			wantErrContains: "needs authentication",
+		},
+		{
+			name: "non-ephemeral service without existing state but with OAuth",
+			cfg: config.Tailscale{
+				OAuthClientID:     "test-id",
+				OAuthClientSecret: config.RedactedString("test-secret"),
+			},
+			svc: config.Service{
+				Name: "test-service",
+				Tags: []string{"tag:test"},
+			},
+			setupStateDir: false,
+			wantErr:       false,
+		},
+		{
+			name: "non-ephemeral service without existing state but with authkey",
+			cfg: config.Tailscale{
+				AuthKey: config.RedactedString("tskey-auth-123"),
+			},
+			svc: config.Service{
+				Name: "test-service",
+			},
+			setupStateDir: false,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for state
+			tmpDir := t.TempDir()
+
+			// If test requires existing state, create it
+			if tt.setupStateDir {
+				serviceStateDir := filepath.Join(tmpDir, tt.svc.Name)
+				err := os.MkdirAll(serviceStateDir, 0700)
+				require.NoError(t, err)
+
+				// Create a mock state file
+				stateFile := filepath.Join(serviceStateDir, "tailscaled.state")
+				err = os.WriteFile(stateFile, []byte("mock state"), 0600)
+				require.NoError(t, err)
+			}
+
+			// Create mock TSNetServer
+			mockServer := tsnet.NewMockTSNetServer()
+
+			// Create server with mock factory
+			factory := func() tsnet.TSNetServer {
+				return mockServer
+			}
+			server, err := NewServerWithFactory(tt.cfg, factory)
+			require.NoError(t, err)
+
+			// Test prepareServiceAuth
+			err = server.prepareServiceAuth(mockServer, tt.svc, tmpDir)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tt.wantErrContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }
@@ -968,17 +1114,17 @@ func TestResolveAuthConfiguration(t *testing.T) {
 				wantErr: false,
 			},
 			{
-				name:    "no credentials provided",
+				name:    "no credentials provided is now allowed",
 				cfg:     config.Tailscale{},
-				wantErr: true,
+				wantErr: false,
 			},
 			{
-				name: "incomplete OAuth credentials",
+				name: "incomplete OAuth credentials is now allowed",
 				cfg: config.Tailscale{
 					OAuthClientID: "client-id",
 					// Missing secret
 				},
-				wantErr: true,
+				wantErr: false,
 			},
 		}
 

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -65,14 +65,14 @@ func TestNewServer(t *testing.T) {
 			cfg: config.Tailscale{
 				OAuthClientID: "test-client-id",
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "incomplete OAuth - missing ID is still allowed",
 			cfg: config.Tailscale{
 				OAuthClientSecret: config.RedactedString("test-client-secret"),
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 
@@ -1124,7 +1124,7 @@ func TestResolveAuthConfiguration(t *testing.T) {
 					OAuthClientID: "client-id",
 					// Missing secret
 				},
-				wantErr: false,
+				wantErr: true,
 			},
 		}
 


### PR DESCRIPTION
Previously, tsbridge required OAuth credentials or an authkey at startup even when all services had existing state files. This change defers authentication validation until it's actually needed, allowing services with existing tsnet state to run without credentials.

Changes:
- Modified config validation to allow missing auth credentials at startup
- Added deferred validation in tailscale package when creating new services
- Preserved validation for partial OAuth configurations (ID without secret)
- Updated tests to reflect new behavior

This enables use cases where tsbridge manages already-registered services without needing to store or provide authentication credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for OAuth credentials, now allowing both credentials to be missing but enforcing that if one is provided, the other must also be present.
  * Adjusted authentication validation timing, deferring checks until service setup rather than at server creation.

* **Tests**
  * Updated and expanded test cases to reflect new OAuth validation logic and authentication handling.
  * Added comprehensive tests for service authentication preparation, covering various configuration scenarios.

* **Other Improvements**
  * Enhanced output verification in configuration validation tests for more robust log and stdout checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->