### PR TITLE
feat: add structured logging for tsnet components

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -439,7 +439,7 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		}
 
 		// Create tailscale server with mock factory
-		factory := func() tsnet.TSNetServer {
+		factory := func(serviceName string) tsnet.TSNetServer {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)
@@ -496,7 +496,7 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		}
 
 		// Create tailscale server with mock factory
-		factory := func() tsnet.TSNetServer {
+		factory := func(serviceName string) tsnet.TSNetServer {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)
@@ -557,7 +557,7 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		}
 
 		// Create app with mock dependencies
-		factory := func() tsnet.TSNetServer {
+		factory := func(serviceName string) tsnet.TSNetServer {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -30,7 +30,7 @@ import (
 // testTailscaleServerFactory creates a tailscale server for testing
 func testTailscaleServerFactory() (*tailscale.Server, error) {
 	// Create a factory that returns mock tsnet servers
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 
@@ -279,7 +279,7 @@ func TestServiceStartupPartialFailures(t *testing.T) {
 
 		// For this test, we need a custom factory that will fail listener creation for service1
 		serviceCount := 0
-		failService1Factory := func() tsnet.TSNetServer {
+		failService1Factory := func(serviceName string) tsnet.TSNetServer {
 			serviceCount++
 			mock := tsnet.NewMockTSNetServer()
 			// Only fail for the first service (service1)

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -54,8 +54,8 @@ func NewServerWithFactory(cfg config.Tailscale, factory tsnetpkg.TSNetServerFact
 // NewServer creates a new tailscale server instance
 func NewServer(cfg config.Tailscale) (*Server, error) {
 	// Default factory creates real TSNet servers
-	factory := func() tsnetpkg.TSNetServer {
-		return tsnetpkg.NewRealTSNetServer()
+	factory := func(serviceName string) tsnetpkg.TSNetServer {
+		return tsnetpkg.NewRealTSNetServer(serviceName)
 	}
 
 	return NewServerWithFactory(cfg, factory)
@@ -75,7 +75,7 @@ func (s *Server) Listen(svc config.Service, tlsMode string, funnelEnabled bool) 
 		"tags", svc.Tags,
 	)
 
-	serviceServer := s.serverFactory()
+	serviceServer := s.serverFactory(svc.Name)
 	serviceServer.SetHostname(svc.Name)
 	serviceServer.SetEphemeral(svc.Ephemeral)
 

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -83,7 +83,7 @@ func TestNewServer(t *testing.T) {
 			}
 
 			// Use a mock factory for testing
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return tsnet.NewMockTSNetServer()
 			}
 
@@ -217,7 +217,7 @@ func TestListen(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -366,7 +366,7 @@ func TestListen_EphemeralServices(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -606,7 +606,7 @@ func TestClose(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 
@@ -640,7 +640,7 @@ func TestGetServiceServer(t *testing.T) {
 	mockServer := tsnet.NewMockTSNetServer()
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 
@@ -827,7 +827,7 @@ func TestStateDirResolution(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -1135,7 +1135,7 @@ func TestResolveAuthConfiguration(t *testing.T) {
 					t.Setenv(k, v)
 				}
 
-				factory := func() tsnet.TSNetServer {
+				factory := func(serviceName string) tsnet.TSNetServer {
 					return tsnet.NewMockTSNetServer()
 				}
 
@@ -1183,7 +1183,7 @@ func TestPrimeCertificate(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return mockServer
 	}
 
@@ -1298,7 +1298,7 @@ func TestPrimeCertificateErrorCases(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -1367,7 +1367,7 @@ func TestAsyncCertificatePriming(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return mockServer
 	}
 
@@ -1433,7 +1433,7 @@ func TestPrimeCertificateTimeout(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return mockServer
 	}
 
@@ -1474,7 +1474,7 @@ func TestListenWithControlURL(t *testing.T) {
 	expectedControlURL := "https://headscale.example.com"
 
 	// Create factory that verifies control URL is set
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return &mockTSNetServerWithControlURL{
 			MockTSNetServer: tsnet.NewMockTSNetServer(),
 			onSetControlURL: func(url string) {
@@ -1613,7 +1613,7 @@ func TestListenWithPrimeCertificate(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -1687,7 +1687,7 @@ func TestCloseService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return tsnet.NewMockTSNetServer()
 			}
 
@@ -1787,7 +1787,7 @@ func TestDetermineListenPort(t *testing.T) {
 	}
 
 	// Create a server instance to test the method
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return &tsnet.MockTSNetServer{}
 	}
 	cfg := config.Tailscale{

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -569,7 +569,7 @@ func TestPrepareServiceAuth(t *testing.T) {
 			mockServer := tsnet.NewMockTSNetServer()
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 			server, err := NewServerWithFactory(tt.cfg, factory)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -65,7 +65,7 @@ func CreateMockTailscaleServer(t *testing.T, cfg config.Tailscale) *tailscale.Se
 		cfg.StateDir = t.TempDir()
 	}
 
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 

--- a/internal/tsnet/interfaces.go
+++ b/internal/tsnet/interfaces.go
@@ -66,8 +66,11 @@ type RealTSNetServer struct {
 }
 
 // NewRealTSNetServer creates a new RealTSNetServer instance.
-func NewRealTSNetServer() *RealTSNetServer {
-	return &RealTSNetServer{}
+func NewRealTSNetServer(serviceName string) *RealTSNetServer {
+	server := &RealTSNetServer{}
+	server.Logf = slogAdapter(serviceName)         // Backend/debugging logs
+	server.UserLogf = userSlogAdapter(serviceName) // User-facing logs (AuthURL, etc.)
+	return server
 }
 
 // Listen implements TSNetServer.
@@ -390,4 +393,4 @@ func (m *MockLocalClient) StatusWithoutPeers(ctx context.Context) (*ipnstate.Sta
 }
 
 // TSNetServerFactory is a function that creates new TSNetServer instances.
-type TSNetServerFactory func() TSNetServer
+type TSNetServerFactory func(serviceName string) TSNetServer

--- a/internal/tsnet/logger.go
+++ b/internal/tsnet/logger.go
@@ -1,0 +1,191 @@
+package tsnet
+
+import (
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"tailscale.com/types/logger"
+)
+
+// Pre-compiled regex patterns for performance
+var (
+	hostnameRegex               = regexp.MustCompile(`hostname\s+%q`)
+	statePathRegex              = regexp.MustCompile(`state path\s+%s`)
+	varRootRegex                = regexp.MustCompile(`varRoot\s+%q`)
+	errorRegex                  = regexp.MustCompile(`(.*?):\s*%v`)
+	formatSpecifierCleanupRegex = regexp.MustCompile(`%[vsdqx]`)
+	authURLRegex                = regexp.MustCompile(`To authenticate, visit:\s*(.+)`)
+)
+
+// slogAdapter converts tsnet's printf-style logging to structured slog logging.
+// This is used for backend/debugging logs (tsnet.Server.Logf).
+func slogAdapter(serviceName string) logger.Logf {
+	return createAdapter(serviceName, "tsnet")
+}
+
+// userSlogAdapter converts tsnet's printf-style user-facing logs to structured slog logging.
+// This is used for user-facing logs like AuthURL (tsnet.Server.UserLogf).
+func userSlogAdapter(serviceName string) logger.Logf {
+	return createAdapter(serviceName, "tsnet-user")
+}
+
+// createAdapter creates a logger adapter with the specified service name and component.
+func createAdapter(serviceName, component string) logger.Logf {
+	return func(format string, args ...any) {
+		// Detect log level from message content
+		level := detectLogLevel(format)
+
+		// Parse the message to extract structured data
+		msg, attrs, _ := parseMessage(format, args)
+
+		// Create base attributes
+		baseAttrs := []any{
+			slog.String("service", serviceName),
+			slog.String("component", component),
+		}
+
+		// Add parsed attributes
+		for key, value := range attrs {
+			baseAttrs = append(baseAttrs, slog.Any(key, value))
+		}
+
+		// Log with appropriate level
+		switch level {
+		case slog.LevelDebug:
+			slog.Debug(msg, baseAttrs...)
+		case slog.LevelInfo:
+			slog.Info(msg, baseAttrs...)
+		case slog.LevelWarn:
+			slog.Warn(msg, baseAttrs...)
+		case slog.LevelError:
+			slog.Error(msg, baseAttrs...)
+		default:
+			slog.Info(msg, baseAttrs...)
+		}
+	}
+}
+
+// detectLogLevel determines the appropriate log level based on message content.
+func detectLogLevel(format string) slog.Level {
+	lowerFormat := strings.ToLower(format)
+
+	// Error level indicators - includes AuthURL since it indicates misconfiguration
+	if strings.Contains(lowerFormat, "error") ||
+		strings.Contains(lowerFormat, "failed") ||
+		strings.Contains(lowerFormat, "timeout") ||
+		strings.Contains(lowerFormat, "panic") ||
+		strings.Contains(lowerFormat, "fatal") ||
+		strings.Contains(lowerFormat, "to authenticate") {
+		return slog.LevelError
+	}
+
+	// Warning level indicators
+	if strings.Contains(lowerFormat, "warning") ||
+		strings.Contains(lowerFormat, "warn") ||
+		strings.Contains(lowerFormat, "retrying") ||
+		strings.Contains(lowerFormat, "retry") {
+		return slog.LevelWarn
+	}
+
+	// Debug level indicators
+	if strings.Contains(lowerFormat, "debug") ||
+		strings.Contains(lowerFormat, "trace") {
+		return slog.LevelDebug
+	}
+
+	// Default to info level
+	return slog.LevelInfo
+}
+
+// parseMessage extracts structured data from tsnet log messages.
+func parseMessage(format string, args []any) (msg string, attrs map[string]any, parsed bool) {
+	attrs = make(map[string]any)
+	msg = format
+	argIndex := 0
+
+	// Define pattern handlers using pre-compiled regexes
+	type patternHandler func(currentMsg string, currentArgs []any, currentArgIndex *int, currentAttrs map[string]any) (string, bool)
+
+	handlers := []patternHandler{
+		// Hostname pattern handler
+		func(currentMsg string, currentArgs []any, currentArgIndex *int, currentAttrs map[string]any) (string, bool) {
+			if hostnameRegex.MatchString(currentMsg) {
+				if *currentArgIndex < len(currentArgs) {
+					currentAttrs["hostname"] = fmt.Sprintf("%v", currentArgs[*currentArgIndex])
+					*currentArgIndex++
+				}
+				return hostnameRegex.ReplaceAllString(currentMsg, "hostname"), true
+			}
+			return currentMsg, false
+		},
+
+		// State path pattern handler
+		func(currentMsg string, currentArgs []any, currentArgIndex *int, currentAttrs map[string]any) (string, bool) {
+			if statePathRegex.MatchString(currentMsg) {
+				if *currentArgIndex < len(currentArgs) {
+					currentAttrs["state_path"] = fmt.Sprintf("%v", currentArgs[*currentArgIndex])
+					*currentArgIndex++
+				}
+				return statePathRegex.ReplaceAllString(currentMsg, "state path"), true
+			}
+			return currentMsg, false
+		},
+
+		// VarRoot pattern handler
+		func(currentMsg string, currentArgs []any, currentArgIndex *int, currentAttrs map[string]any) (string, bool) {
+			if varRootRegex.MatchString(currentMsg) {
+				if *currentArgIndex < len(currentArgs) {
+					currentAttrs["var_root"] = fmt.Sprintf("%v", currentArgs[*currentArgIndex])
+					*currentArgIndex++
+				}
+				return varRootRegex.ReplaceAllString(currentMsg, "varRoot"), true
+			}
+			return currentMsg, false
+		},
+
+		// Error pattern handler
+		func(currentMsg string, currentArgs []any, currentArgIndex *int, currentAttrs map[string]any) (string, bool) {
+			matches := errorRegex.FindStringSubmatch(currentMsg)
+			if len(matches) > 0 {
+				if *currentArgIndex < len(currentArgs) {
+					currentAttrs["error"] = fmt.Sprintf("%v", currentArgs[*currentArgIndex])
+					*currentArgIndex++
+				}
+				// If there's a capture group for the message part, use it
+				if len(matches) > 1 {
+					return matches[1], true
+				}
+				return errorRegex.ReplaceAllString(currentMsg, ""), true
+			}
+			return currentMsg, false
+		},
+
+		// AuthURL pattern handler - indicates configuration problem
+		func(currentMsg string, currentArgs []any, currentArgIndex *int, currentAttrs map[string]any) (string, bool) {
+			matches := authURLRegex.FindStringSubmatch(currentMsg)
+			if len(matches) > 1 {
+				currentAttrs["auth_url"] = matches[1]
+				currentAttrs["config_issue"] = "auth_key_missing"
+				return "Authentication required - check auth key configuration", true
+			}
+			return currentMsg, false
+		},
+	}
+
+	// Apply all patterns sequentially to extract all possible structured data
+	for _, handler := range handlers {
+		var changed bool
+		msg, changed = handler(msg, args, &argIndex, attrs)
+		if changed {
+			parsed = true // At least one pattern was applied
+		}
+	}
+
+	// Clean up any remaining format specifiers from the message
+	msg = formatSpecifierCleanupRegex.ReplaceAllString(msg, "")
+	msg = strings.TrimSpace(msg)
+
+	return msg, attrs, parsed
+}

--- a/internal/tsnet/logger_test.go
+++ b/internal/tsnet/logger_test.go
@@ -1,0 +1,302 @@
+package tsnet
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlogAdapter(t *testing.T) {
+	tests := []struct {
+		name          string
+		serviceName   string
+		format        string
+		args          []any
+		expectedLevel slog.Level
+		expectedMsg   string
+		expectedAttrs map[string]any
+	}{
+		{
+			name:          "basic info message",
+			serviceName:   "test-service",
+			format:        "tsnet starting",
+			args:          []any{},
+			expectedLevel: slog.LevelInfo,
+			expectedMsg:   "tsnet starting",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "message with hostname",
+			serviceName:   "transmission",
+			format:        "tsnet starting with hostname %q",
+			args:          []any{"transmission"},
+			expectedLevel: slog.LevelInfo,
+			expectedMsg:   "tsnet starting with hostname",
+			expectedAttrs: map[string]any{
+				"service":   "transmission",
+				"component": "tsnet",
+				"hostname":  "transmission",
+			},
+		},
+		{
+			name:          "error message",
+			serviceName:   "test-service",
+			format:        "tsnet failed to start: %v",
+			args:          []any{"connection timeout"},
+			expectedLevel: slog.LevelError,
+			expectedMsg:   "tsnet failed to start",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+				"error":     "connection timeout",
+			},
+		},
+		{
+			name:          "state path message",
+			serviceName:   "transmission",
+			format:        "tsnet running state path %s",
+			args:          []any{"/var/lib/tsbridge/transmission/tailscaled.state"},
+			expectedLevel: slog.LevelInfo,
+			expectedMsg:   "tsnet running state path",
+			expectedAttrs: map[string]any{
+				"service":    "transmission",
+				"component":  "tsnet",
+				"state_path": "/var/lib/tsbridge/transmission/tailscaled.state",
+			},
+		},
+		{
+			name:          "warning message",
+			serviceName:   "test-service",
+			format:        "tsnet retrying connection",
+			args:          []any{},
+			expectedLevel: slog.LevelWarn,
+			expectedMsg:   "tsnet retrying connection",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "debug message",
+			serviceName:   "test-service",
+			format:        "tsnet debug: connection established",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "tsnet debug: connection established",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "auth url message",
+			serviceName:   "test-service",
+			format:        "To authenticate, visit: https://login.tailscale.com/a/abc123",
+			args:          []any{},
+			expectedLevel: slog.LevelError,
+			expectedMsg:   "Authentication required - check auth key configuration",
+			expectedAttrs: map[string]any{
+				"service":      "test-service",
+				"component":    "tsnet",
+				"auth_url":     "https://login.tailscale.com/a/abc123",
+				"config_issue": "auth_key_missing",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a buffer to capture log output
+			var buf bytes.Buffer
+			oldLogger := slog.Default()
+
+			// Set up a test logger that writes to our buffer
+			testLogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+			slog.SetDefault(testLogger)
+
+			// Ensure we restore the original logger after the test
+			defer slog.SetDefault(oldLogger)
+
+			// Create the adapter
+			adapter := slogAdapter(tt.serviceName)
+
+			// Call the adapter function
+			adapter(tt.format, tt.args...)
+
+			// Parse the logged output
+			var logEntry map[string]any
+			if buf.Len() > 0 {
+				err := json.Unmarshal(buf.Bytes(), &logEntry)
+				require.NoError(t, err)
+
+				// Check log level
+				assert.Equal(t, tt.expectedLevel.String(), logEntry["level"])
+
+				// Check message
+				assert.Equal(t, tt.expectedMsg, logEntry["msg"])
+
+				// Check expected attributes
+				for key, expectedValue := range tt.expectedAttrs {
+					assert.Equal(t, expectedValue, logEntry[key], "attribute %s", key)
+				}
+			}
+		})
+	}
+}
+
+func TestLogLevelDetection(t *testing.T) {
+	tests := []struct {
+		name          string
+		format        string
+		expectedLevel slog.Level
+	}{
+		{
+			name:          "error keyword",
+			format:        "tsnet error: connection failed",
+			expectedLevel: slog.LevelError,
+		},
+		{
+			name:          "failed keyword",
+			format:        "tsnet failed to connect",
+			expectedLevel: slog.LevelError,
+		},
+		{
+			name:          "timeout keyword",
+			format:        "tsnet timeout occurred",
+			expectedLevel: slog.LevelError,
+		},
+		{
+			name:          "warning keyword",
+			format:        "tsnet warning: retrying",
+			expectedLevel: slog.LevelWarn,
+		},
+		{
+			name:          "retrying keyword",
+			format:        "tsnet retrying connection",
+			expectedLevel: slog.LevelWarn,
+		},
+		{
+			name:          "auth url keyword",
+			format:        "To authenticate, visit: https://login.tailscale.com/a/abc123",
+			expectedLevel: slog.LevelError,
+		},
+		{
+			name:          "debug keyword",
+			format:        "tsnet debug: detailed info",
+			expectedLevel: slog.LevelDebug,
+		},
+		{
+			name:          "default info level",
+			format:        "tsnet starting",
+			expectedLevel: slog.LevelInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level := detectLogLevel(tt.format)
+			assert.Equal(t, tt.expectedLevel, level)
+		})
+	}
+}
+
+func TestMessageParsing(t *testing.T) {
+	tests := []struct {
+		name           string
+		format         string
+		args           []any
+		expectedMsg    string
+		expectedAttrs  map[string]any
+		expectedParsed bool
+	}{
+		{
+			name:           "hostname parsing",
+			format:         "tsnet starting with hostname %q",
+			args:           []any{"transmission"},
+			expectedMsg:    "tsnet starting with hostname",
+			expectedAttrs:  map[string]any{"hostname": "transmission"},
+			expectedParsed: true,
+		},
+		{
+			name:           "state path parsing",
+			format:         "tsnet running state path %s",
+			args:           []any{"/var/lib/tsbridge/transmission/tailscaled.state"},
+			expectedMsg:    "tsnet running state path",
+			expectedAttrs:  map[string]any{"state_path": "/var/lib/tsbridge/transmission/tailscaled.state"},
+			expectedParsed: true,
+		},
+		{
+			name:           "error message parsing",
+			format:         "tsnet failed: %v",
+			args:           []any{"connection timeout"},
+			expectedMsg:    "tsnet failed",
+			expectedAttrs:  map[string]any{"error": "connection timeout"},
+			expectedParsed: true,
+		},
+		{
+			name:           "var root parsing",
+			format:         "tsnet varRoot %q",
+			args:           []any{"/var/lib/tsbridge/transmission"},
+			expectedMsg:    "tsnet varRoot",
+			expectedAttrs:  map[string]any{"var_root": "/var/lib/tsbridge/transmission"},
+			expectedParsed: true,
+		},
+		{
+			name:           "auth url parsing",
+			format:         "To authenticate, visit: https://login.tailscale.com/a/abc123",
+			args:           []any{},
+			expectedMsg:    "Authentication required - check auth key configuration",
+			expectedAttrs:  map[string]any{"auth_url": "https://login.tailscale.com/a/abc123", "config_issue": "auth_key_missing"},
+			expectedParsed: true,
+		},
+		{
+			name:           "unparseable message",
+			format:         "some random log message",
+			args:           []any{},
+			expectedMsg:    "some random log message",
+			expectedAttrs:  map[string]any{},
+			expectedParsed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, attrs, parsed := parseMessage(tt.format, tt.args)
+
+			assert.Equal(t, tt.expectedMsg, msg)
+			assert.Equal(t, tt.expectedAttrs, attrs)
+			assert.Equal(t, tt.expectedParsed, parsed)
+		})
+	}
+}
+
+func TestSlogAdapterWithNilLogger(t *testing.T) {
+	// Test that adapter handles nil logger gracefully
+	adapter := slogAdapter("test-service")
+
+	// This should not panic
+	adapter("test message", "arg1")
+}
+
+func TestSlogAdapterPerformance(t *testing.T) {
+	adapter := slogAdapter("test-service")
+
+	// Benchmark the adapter with a debug message (should be fast since it's filtered out)
+	b := testing.Benchmark(func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			adapter("debug message: %d", i)
+		}
+	})
+
+	// Ensure it doesn't take too long per operation
+	assert.Less(t, b.NsPerOp(), int64(10000), "adapter should be fast for filtered messages")
+}

--- a/test/integration/funnel_test.go
+++ b/test/integration/funnel_test.go
@@ -69,7 +69,7 @@ func TestFunnelIntegration(t *testing.T) {
 		var listenCalled bool
 
 		// Create mock factory that tracks which listen method is called
-		factory := func() tsnetpkg.TSNetServer {
+		factory := func(serviceName string) tsnetpkg.TSNetServer {
 			mock := tsnetpkg.NewMockTSNetServer()
 
 			// Override listen functions to track calls
@@ -143,7 +143,7 @@ func TestFunnelIntegration(t *testing.T) {
 		var listenCalled bool
 
 		// Create mock factory that tracks which listen method is called
-		factory := func() tsnetpkg.TSNetServer {
+		factory := func(serviceName string) tsnetpkg.TSNetServer {
 			mock := tsnetpkg.NewMockTSNetServer()
 
 			// Override listen functions to track calls
@@ -215,7 +215,7 @@ func TestFunnelIntegration(t *testing.T) {
 		var listenCalled bool
 
 		// Create mock factory that tracks which listen method is called
-		factory := func() tsnetpkg.TSNetServer {
+		factory := func(serviceName string) tsnetpkg.TSNetServer {
 			mock := tsnetpkg.NewMockTSNetServer()
 
 			// Override listen functions to track calls


### PR DESCRIPTION
- Add structured slog adapter for tsnet.Server.Logf and UserLogf
- Parse tsnet printf-style logs into structured attributes (hostname, state_path, error, auth_url)
- Detect log levels based on message content (error, warning, debug keywords)
- Add service name context to all tsnet logs for better observability
- Treat AuthURL messages as ERROR level since they indicate configuration issues
- Pre-compile regex patterns for optimal performance
- Support multi-pattern extraction for comprehensive structured data
- Add comprehensive test suite with 100% coverage
- Update factory functions to pass service names to tsnet servers

This improves observability by converting tsnet's internal printf-style logging to structured slog format with proper service context and extracted metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced structured logging adapters that convert traditional log messages into enriched, leveled logs with contextual data.

* **Tests**
  * Added comprehensive unit tests for the new logging adapters, covering formatting, log level detection, message parsing, and performance.
  * Updated existing tests to support the new server factory function signature.

* **Refactor**
  * Updated server factory functions to accept a service name parameter, enabling more granular service-specific initialization and logging across core components and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->