### PR TITLE
feat: add tsnet logging adapters to reduce log noise

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -439,7 +439,7 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		}
 
 		// Create tailscale server with mock factory
-		factory := func() tsnet.TSNetServer {
+		factory := func(serviceName string) tsnet.TSNetServer {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)
@@ -496,7 +496,7 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		}
 
 		// Create tailscale server with mock factory
-		factory := func() tsnet.TSNetServer {
+		factory := func(serviceName string) tsnet.TSNetServer {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)
@@ -557,7 +557,7 @@ func TestAppStartWithPartialServiceFailures(t *testing.T) {
 		}
 
 		// Create app with mock dependencies
-		factory := func() tsnet.TSNetServer {
+		factory := func(serviceName string) tsnet.TSNetServer {
 			return tsnet.NewMockTSNetServer()
 		}
 		tsServer, err := tailscale.NewServerWithFactory(cfg.Tailscale, factory)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -30,7 +30,7 @@ import (
 // testTailscaleServerFactory creates a tailscale server for testing
 func testTailscaleServerFactory() (*tailscale.Server, error) {
 	// Create a factory that returns mock tsnet servers
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 
@@ -279,7 +279,7 @@ func TestServiceStartupPartialFailures(t *testing.T) {
 
 		// For this test, we need a custom factory that will fail listener creation for service1
 		serviceCount := 0
-		failService1Factory := func() tsnet.TSNetServer {
+		failService1Factory := func(serviceName string) tsnet.TSNetServer {
 			serviceCount++
 			mock := tsnet.NewMockTSNetServer()
 			// Only fail for the first service (service1)

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -54,8 +54,8 @@ func NewServerWithFactory(cfg config.Tailscale, factory tsnetpkg.TSNetServerFact
 // NewServer creates a new tailscale server instance
 func NewServer(cfg config.Tailscale) (*Server, error) {
 	// Default factory creates real TSNet servers
-	factory := func() tsnetpkg.TSNetServer {
-		return tsnetpkg.NewRealTSNetServer()
+	factory := func(serviceName string) tsnetpkg.TSNetServer {
+		return tsnetpkg.NewRealTSNetServer(serviceName)
 	}
 
 	return NewServerWithFactory(cfg, factory)
@@ -75,7 +75,7 @@ func (s *Server) Listen(svc config.Service, tlsMode string, funnelEnabled bool) 
 		"tags", svc.Tags,
 	)
 
-	serviceServer := s.serverFactory()
+	serviceServer := s.serverFactory(svc.Name)
 	serviceServer.SetHostname(svc.Name)
 	serviceServer.SetEphemeral(svc.Ephemeral)
 

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -83,7 +83,7 @@ func TestNewServer(t *testing.T) {
 			}
 
 			// Use a mock factory for testing
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return tsnet.NewMockTSNetServer()
 			}
 
@@ -217,7 +217,7 @@ func TestListen(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -366,7 +366,7 @@ func TestListen_EphemeralServices(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -569,7 +569,7 @@ func TestPrepareServiceAuth(t *testing.T) {
 			mockServer := tsnet.NewMockTSNetServer()
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 			server, err := NewServerWithFactory(tt.cfg, factory)
@@ -606,7 +606,7 @@ func TestClose(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 
@@ -640,7 +640,7 @@ func TestGetServiceServer(t *testing.T) {
 	mockServer := tsnet.NewMockTSNetServer()
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 
@@ -827,7 +827,7 @@ func TestStateDirResolution(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -1135,7 +1135,7 @@ func TestResolveAuthConfiguration(t *testing.T) {
 					t.Setenv(k, v)
 				}
 
-				factory := func() tsnet.TSNetServer {
+				factory := func(serviceName string) tsnet.TSNetServer {
 					return tsnet.NewMockTSNetServer()
 				}
 
@@ -1183,7 +1183,7 @@ func TestPrimeCertificate(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return mockServer
 	}
 
@@ -1298,7 +1298,7 @@ func TestPrimeCertificateErrorCases(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -1367,7 +1367,7 @@ func TestAsyncCertificatePriming(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return mockServer
 	}
 
@@ -1433,7 +1433,7 @@ func TestPrimeCertificateTimeout(t *testing.T) {
 	}
 
 	// Create server with mock factory
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return mockServer
 	}
 
@@ -1474,7 +1474,7 @@ func TestListenWithControlURL(t *testing.T) {
 	expectedControlURL := "https://headscale.example.com"
 
 	// Create factory that verifies control URL is set
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return &mockTSNetServerWithControlURL{
 			MockTSNetServer: tsnet.NewMockTSNetServer(),
 			onSetControlURL: func(url string) {
@@ -1613,7 +1613,7 @@ func TestListenWithPrimeCertificate(t *testing.T) {
 			}
 
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return mockServer
 			}
 
@@ -1687,7 +1687,7 @@ func TestCloseService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create server with mock factory
-			factory := func() tsnet.TSNetServer {
+			factory := func(serviceName string) tsnet.TSNetServer {
 				return tsnet.NewMockTSNetServer()
 			}
 
@@ -1787,7 +1787,7 @@ func TestDetermineListenPort(t *testing.T) {
 	}
 
 	// Create a server instance to test the method
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return &tsnet.MockTSNetServer{}
 	}
 	cfg := config.Tailscale{

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -65,7 +65,7 @@ func CreateMockTailscaleServer(t *testing.T, cfg config.Tailscale) *tailscale.Se
 		cfg.StateDir = t.TempDir()
 	}
 
-	factory := func() tsnet.TSNetServer {
+	factory := func(serviceName string) tsnet.TSNetServer {
 		return tsnet.NewMockTSNetServer()
 	}
 

--- a/internal/tsnet/interfaces.go
+++ b/internal/tsnet/interfaces.go
@@ -66,8 +66,11 @@ type RealTSNetServer struct {
 }
 
 // NewRealTSNetServer creates a new RealTSNetServer instance.
-func NewRealTSNetServer() *RealTSNetServer {
-	return &RealTSNetServer{}
+func NewRealTSNetServer(serviceName string) *RealTSNetServer {
+	server := &RealTSNetServer{}
+	server.Logf = slogAdapter(serviceName)         // Backend/debugging logs
+	server.UserLogf = userSlogAdapter(serviceName) // User-facing logs (AuthURL, etc.)
+	return server
 }
 
 // Listen implements TSNetServer.
@@ -390,4 +393,4 @@ func (m *MockLocalClient) StatusWithoutPeers(ctx context.Context) (*ipnstate.Sta
 }
 
 // TSNetServerFactory is a function that creates new TSNetServer instances.
-type TSNetServerFactory func() TSNetServer
+type TSNetServerFactory func(serviceName string) TSNetServer

--- a/internal/tsnet/interfaces.go
+++ b/internal/tsnet/interfaces.go
@@ -68,8 +68,9 @@ type RealTSNetServer struct {
 // NewRealTSNetServer creates a new RealTSNetServer instance.
 func NewRealTSNetServer(serviceName string) *RealTSNetServer {
 	server := &RealTSNetServer{}
-	server.Logf = slogAdapter(serviceName)         // Backend/debugging logs
-	server.UserLogf = userSlogAdapter(serviceName) // User-facing logs (AuthURL, etc.)
+	adapter := tsnetLogAdapter(serviceName)
+	server.Logf = adapter     // Backend/debugging logs
+	server.UserLogf = adapter // User-facing logs (AuthURL, etc.)
 	return server
 }
 

--- a/internal/tsnet/logger.go
+++ b/internal/tsnet/logger.go
@@ -1,37 +1,20 @@
 package tsnet
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 
 	"tailscale.com/types/logger"
 )
 
-// slogAdapter converts tsnet's printf-style logging to structured slog logging.
-// This is used for backend/debugging logs (tsnet.Server.Logf).
-// All TSNet internal logs are treated as debug level to reduce log chattiness.
-func slogAdapter(serviceName string) logger.Logf {
-	return createAdapter(serviceName, "tsnet", slog.LevelDebug)
-}
-
-// userSlogAdapter converts tsnet's printf-style user-facing logs to structured slog logging.
-// This is used for user-facing logs like AuthURL (tsnet.Server.UserLogf).
-// All user-facing logs are treated as info level.
-func userSlogAdapter(serviceName string) logger.Logf {
-	return createAdapter(serviceName, "tsnet-user", slog.LevelInfo)
-}
-
-// createAdapter creates a logger adapter with the specified service name, component, and log level.
-func createAdapter(serviceName, component string, level slog.Level) logger.Logf {
+// tsnetLogAdapter converts tsnet's printf-style logging to structured slog logging.
+// All TSNet logs are treated as debug level to reduce log chattiness.
+func tsnetLogAdapter(serviceName string) logger.Logf {
 	return func(format string, args ...any) {
 		// Simply format the message using standard printf formatting
 		msg := fmt.Sprintf(format, args...)
 
-		// Log with service and component context
-		slog.Log(context.TODO(), level, msg,
-			slog.String("service", serviceName),
-			slog.String("component", component),
-		)
+		// Log at debug level with service context
+		slog.Debug(msg, slog.String("service", serviceName))
 	}
 }

--- a/internal/tsnet/logger.go
+++ b/internal/tsnet/logger.go
@@ -1,0 +1,37 @@
+package tsnet
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"tailscale.com/types/logger"
+)
+
+// slogAdapter converts tsnet's printf-style logging to structured slog logging.
+// This is used for backend/debugging logs (tsnet.Server.Logf).
+// All TSNet internal logs are treated as debug level to reduce log chattiness.
+func slogAdapter(serviceName string) logger.Logf {
+	return createAdapter(serviceName, "tsnet", slog.LevelDebug)
+}
+
+// userSlogAdapter converts tsnet's printf-style user-facing logs to structured slog logging.
+// This is used for user-facing logs like AuthURL (tsnet.Server.UserLogf).
+// All user-facing logs are treated as info level.
+func userSlogAdapter(serviceName string) logger.Logf {
+	return createAdapter(serviceName, "tsnet-user", slog.LevelInfo)
+}
+
+// createAdapter creates a logger adapter with the specified service name, component, and log level.
+func createAdapter(serviceName, component string, level slog.Level) logger.Logf {
+	return func(format string, args ...any) {
+		// Simply format the message using standard printf formatting
+		msg := fmt.Sprintf(format, args...)
+
+		// Log with service and component context
+		slog.Log(context.TODO(), level, msg,
+			slog.String("service", serviceName),
+			slog.String("component", component),
+		)
+	}
+}

--- a/internal/tsnet/logger_test.go
+++ b/internal/tsnet/logger_test.go
@@ -1,0 +1,333 @@
+package tsnet
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlogAdapter(t *testing.T) {
+	tests := []struct {
+		name          string
+		serviceName   string
+		format        string
+		args          []any
+		expectedLevel slog.Level
+		expectedMsg   string
+		expectedAttrs map[string]any
+	}{
+		{
+			name:          "basic info message",
+			serviceName:   "test-service",
+			format:        "tsnet starting",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "tsnet starting",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "message with hostname",
+			serviceName:   "transmission",
+			format:        "tsnet starting with hostname %q",
+			args:          []any{"transmission"},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "tsnet starting with hostname \"transmission\"",
+			expectedAttrs: map[string]any{
+				"service":   "transmission",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "error message",
+			serviceName:   "test-service",
+			format:        "tsnet failed to start: %v",
+			args:          []any{"connection timeout"},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "tsnet failed to start: connection timeout",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "state path message",
+			serviceName:   "transmission",
+			format:        "tsnet running state path %s",
+			args:          []any{"/var/lib/tsbridge/transmission/tailscaled.state"},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "tsnet running state path /var/lib/tsbridge/transmission/tailscaled.state",
+			expectedAttrs: map[string]any{
+				"service":   "transmission",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "warning message",
+			serviceName:   "test-service",
+			format:        "tsnet retrying connection",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "tsnet retrying connection",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "debug message",
+			serviceName:   "test-service",
+			format:        "tsnet debug: connection established",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "tsnet debug: connection established",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "auth url message",
+			serviceName:   "test-service",
+			format:        "To authenticate, visit: https://login.tailscale.com/a/abc123",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "To authenticate, visit: https://login.tailscale.com/a/abc123",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "magicsock message",
+			serviceName:   "test-service",
+			format:        "magicsock: received packet from peer",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "magicsock: received packet from peer",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "derp message",
+			serviceName:   "test-service",
+			format:        "derp: connected to server",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "derp: connected to server",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "wgengine message",
+			serviceName:   "test-service",
+			format:        "wgengine: updating peer endpoints",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "wgengine: updating peer endpoints",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "control message",
+			serviceName:   "test-service",
+			format:        "control: sending map request",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "control: sending map request",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "netmap message",
+			serviceName:   "test-service",
+			format:        "netmap: got updated network map",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "netmap: got updated network map",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+		{
+			name:          "health check message",
+			serviceName:   "test-service",
+			format:        "health: overall health is good",
+			args:          []any{},
+			expectedLevel: slog.LevelDebug,
+			expectedMsg:   "health: overall health is good",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a buffer to capture log output
+			var buf bytes.Buffer
+			oldLogger := slog.Default()
+
+			// Set up a test logger that writes to our buffer
+			testLogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+			slog.SetDefault(testLogger)
+
+			// Ensure we restore the original logger after the test
+			defer slog.SetDefault(oldLogger)
+
+			// Create the adapter
+			adapter := slogAdapter(tt.serviceName)
+
+			// Call the adapter function
+			adapter(tt.format, tt.args...)
+
+			// Parse the logged output
+			var logEntry map[string]any
+			if buf.Len() > 0 {
+				err := json.Unmarshal(buf.Bytes(), &logEntry)
+				require.NoError(t, err)
+
+				// Check log level
+				assert.Equal(t, tt.expectedLevel.String(), logEntry["level"])
+
+				// Check message
+				assert.Equal(t, tt.expectedMsg, logEntry["msg"])
+
+				// Check expected attributes
+				for key, expectedValue := range tt.expectedAttrs {
+					assert.Equal(t, expectedValue, logEntry[key], "attribute %s", key)
+				}
+			}
+		})
+	}
+}
+
+func TestUserSlogAdapter(t *testing.T) {
+	tests := []struct {
+		name          string
+		serviceName   string
+		format        string
+		args          []any
+		expectedLevel slog.Level
+		expectedMsg   string
+		expectedAttrs map[string]any
+	}{
+		{
+			name:          "basic user message",
+			serviceName:   "test-service",
+			format:        "Service ready",
+			args:          []any{},
+			expectedLevel: slog.LevelInfo,
+			expectedMsg:   "Service ready",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet-user",
+			},
+		},
+		{
+			name:          "auth url message",
+			serviceName:   "test-service",
+			format:        "To authenticate, visit: https://login.tailscale.com/a/abc123",
+			args:          []any{},
+			expectedLevel: slog.LevelInfo,
+			expectedMsg:   "To authenticate, visit: https://login.tailscale.com/a/abc123",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet-user",
+			},
+		},
+		{
+			name:          "error message (still info level)",
+			serviceName:   "test-service",
+			format:        "Error: authentication failed",
+			args:          []any{},
+			expectedLevel: slog.LevelInfo,
+			expectedMsg:   "Error: authentication failed",
+			expectedAttrs: map[string]any{
+				"service":   "test-service",
+				"component": "tsnet-user",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a buffer to capture log output
+			var buf bytes.Buffer
+			oldLogger := slog.Default()
+
+			// Set up a test logger that writes to our buffer
+			testLogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+			slog.SetDefault(testLogger)
+
+			// Ensure we restore the original logger after the test
+			defer slog.SetDefault(oldLogger)
+
+			// Create the adapter
+			adapter := userSlogAdapter(tt.serviceName)
+
+			// Call the adapter function
+			adapter(tt.format, tt.args...)
+
+			// Parse the logged output
+			var logEntry map[string]any
+			if buf.Len() > 0 {
+				err := json.Unmarshal(buf.Bytes(), &logEntry)
+				require.NoError(t, err)
+
+				// Check log level
+				assert.Equal(t, tt.expectedLevel.String(), logEntry["level"])
+
+				// Check message
+				assert.Equal(t, tt.expectedMsg, logEntry["msg"])
+
+				// Check expected attributes
+				for key, expectedValue := range tt.expectedAttrs {
+					assert.Equal(t, expectedValue, logEntry[key], "attribute %s", key)
+				}
+			}
+		})
+	}
+}
+
+func TestSlogAdapterWithNilLogger(t *testing.T) {
+	// Test that adapter handles nil logger gracefully
+	adapter := slogAdapter("test-service")
+
+	// This should not panic
+	adapter("test message", "arg1")
+}
+
+func TestSlogAdapterPerformance(t *testing.T) {
+	adapter := slogAdapter("test-service")
+
+	// Benchmark the adapter with a debug message (should be fast since it's filtered out)
+	b := testing.Benchmark(func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			adapter("debug message: %d", i)
+		}
+	})
+
+	// Ensure it doesn't take too long per operation
+	assert.Less(t, b.NsPerOp(), int64(10000), "adapter should be fast for filtered messages")
+}

--- a/internal/tsnet/logger_test.go
+++ b/internal/tsnet/logger_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSlogAdapter(t *testing.T) {
+func TestTSNetLogAdapter(t *testing.T) {
 	tests := []struct {
 		name          string
 		serviceName   string
@@ -28,8 +28,7 @@ func TestSlogAdapter(t *testing.T) {
 			expectedLevel: slog.LevelDebug,
 			expectedMsg:   "tsnet starting",
 			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
+				"service": "test-service",
 			},
 		},
 		{
@@ -40,8 +39,7 @@ func TestSlogAdapter(t *testing.T) {
 			expectedLevel: slog.LevelDebug,
 			expectedMsg:   "tsnet starting with hostname \"transmission\"",
 			expectedAttrs: map[string]any{
-				"service":   "transmission",
-				"component": "tsnet",
+				"service": "transmission",
 			},
 		},
 		{
@@ -52,8 +50,7 @@ func TestSlogAdapter(t *testing.T) {
 			expectedLevel: slog.LevelDebug,
 			expectedMsg:   "tsnet failed to start: connection timeout",
 			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
+				"service": "test-service",
 			},
 		},
 		{
@@ -64,32 +61,7 @@ func TestSlogAdapter(t *testing.T) {
 			expectedLevel: slog.LevelDebug,
 			expectedMsg:   "tsnet running state path /var/lib/tsbridge/transmission/tailscaled.state",
 			expectedAttrs: map[string]any{
-				"service":   "transmission",
-				"component": "tsnet",
-			},
-		},
-		{
-			name:          "warning message",
-			serviceName:   "test-service",
-			format:        "tsnet retrying connection",
-			args:          []any{},
-			expectedLevel: slog.LevelDebug,
-			expectedMsg:   "tsnet retrying connection",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
-			},
-		},
-		{
-			name:          "debug message",
-			serviceName:   "test-service",
-			format:        "tsnet debug: connection established",
-			args:          []any{},
-			expectedLevel: slog.LevelDebug,
-			expectedMsg:   "tsnet debug: connection established",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
+				"service": "transmission",
 			},
 		},
 		{
@@ -100,8 +72,7 @@ func TestSlogAdapter(t *testing.T) {
 			expectedLevel: slog.LevelDebug,
 			expectedMsg:   "To authenticate, visit: https://login.tailscale.com/a/abc123",
 			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
+				"service": "test-service",
 			},
 		},
 		{
@@ -112,20 +83,7 @@ func TestSlogAdapter(t *testing.T) {
 			expectedLevel: slog.LevelDebug,
 			expectedMsg:   "magicsock: received packet from peer",
 			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
-			},
-		},
-		{
-			name:          "derp message",
-			serviceName:   "test-service",
-			format:        "derp: connected to server",
-			args:          []any{},
-			expectedLevel: slog.LevelDebug,
-			expectedMsg:   "derp: connected to server",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
+				"service": "test-service",
 			},
 		},
 		{
@@ -136,44 +94,7 @@ func TestSlogAdapter(t *testing.T) {
 			expectedLevel: slog.LevelDebug,
 			expectedMsg:   "wgengine: updating peer endpoints",
 			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
-			},
-		},
-		{
-			name:          "control message",
-			serviceName:   "test-service",
-			format:        "control: sending map request",
-			args:          []any{},
-			expectedLevel: slog.LevelDebug,
-			expectedMsg:   "control: sending map request",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
-			},
-		},
-		{
-			name:          "netmap message",
-			serviceName:   "test-service",
-			format:        "netmap: got updated network map",
-			args:          []any{},
-			expectedLevel: slog.LevelDebug,
-			expectedMsg:   "netmap: got updated network map",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
-			},
-		},
-		{
-			name:          "health check message",
-			serviceName:   "test-service",
-			format:        "health: overall health is good",
-			args:          []any{},
-			expectedLevel: slog.LevelDebug,
-			expectedMsg:   "health: overall health is good",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet",
+				"service": "test-service",
 			},
 		},
 	}
@@ -194,7 +115,7 @@ func TestSlogAdapter(t *testing.T) {
 			defer slog.SetDefault(oldLogger)
 
 			// Create the adapter
-			adapter := slogAdapter(tt.serviceName)
+			adapter := tsnetLogAdapter(tt.serviceName)
 
 			// Call the adapter function
 			adapter(tt.format, tt.args...)
@@ -220,106 +141,16 @@ func TestSlogAdapter(t *testing.T) {
 	}
 }
 
-func TestUserSlogAdapter(t *testing.T) {
-	tests := []struct {
-		name          string
-		serviceName   string
-		format        string
-		args          []any
-		expectedLevel slog.Level
-		expectedMsg   string
-		expectedAttrs map[string]any
-	}{
-		{
-			name:          "basic user message",
-			serviceName:   "test-service",
-			format:        "Service ready",
-			args:          []any{},
-			expectedLevel: slog.LevelInfo,
-			expectedMsg:   "Service ready",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet-user",
-			},
-		},
-		{
-			name:          "auth url message",
-			serviceName:   "test-service",
-			format:        "To authenticate, visit: https://login.tailscale.com/a/abc123",
-			args:          []any{},
-			expectedLevel: slog.LevelInfo,
-			expectedMsg:   "To authenticate, visit: https://login.tailscale.com/a/abc123",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet-user",
-			},
-		},
-		{
-			name:          "error message (still info level)",
-			serviceName:   "test-service",
-			format:        "Error: authentication failed",
-			args:          []any{},
-			expectedLevel: slog.LevelInfo,
-			expectedMsg:   "Error: authentication failed",
-			expectedAttrs: map[string]any{
-				"service":   "test-service",
-				"component": "tsnet-user",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a buffer to capture log output
-			var buf bytes.Buffer
-			oldLogger := slog.Default()
-
-			// Set up a test logger that writes to our buffer
-			testLogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
-				Level: slog.LevelDebug,
-			}))
-			slog.SetDefault(testLogger)
-
-			// Ensure we restore the original logger after the test
-			defer slog.SetDefault(oldLogger)
-
-			// Create the adapter
-			adapter := userSlogAdapter(tt.serviceName)
-
-			// Call the adapter function
-			adapter(tt.format, tt.args...)
-
-			// Parse the logged output
-			var logEntry map[string]any
-			if buf.Len() > 0 {
-				err := json.Unmarshal(buf.Bytes(), &logEntry)
-				require.NoError(t, err)
-
-				// Check log level
-				assert.Equal(t, tt.expectedLevel.String(), logEntry["level"])
-
-				// Check message
-				assert.Equal(t, tt.expectedMsg, logEntry["msg"])
-
-				// Check expected attributes
-				for key, expectedValue := range tt.expectedAttrs {
-					assert.Equal(t, expectedValue, logEntry[key], "attribute %s", key)
-				}
-			}
-		})
-	}
-}
-
-func TestSlogAdapterWithNilLogger(t *testing.T) {
+func TestTSNetLogAdapterWithNilLogger(t *testing.T) {
 	// Test that adapter handles nil logger gracefully
-	adapter := slogAdapter("test-service")
+	adapter := tsnetLogAdapter("test-service")
 
 	// This should not panic
 	adapter("test message", "arg1")
 }
 
-func TestSlogAdapterPerformance(t *testing.T) {
-	adapter := slogAdapter("test-service")
+func TestTSNetLogAdapterPerformance(t *testing.T) {
+	adapter := tsnetLogAdapter("test-service")
 
 	// Benchmark the adapter with a debug message (should be fast since it's filtered out)
 	b := testing.Benchmark(func(b *testing.B) {

--- a/test/integration/funnel_test.go
+++ b/test/integration/funnel_test.go
@@ -69,7 +69,7 @@ func TestFunnelIntegration(t *testing.T) {
 		var listenCalled bool
 
 		// Create mock factory that tracks which listen method is called
-		factory := func() tsnetpkg.TSNetServer {
+		factory := func(serviceName string) tsnetpkg.TSNetServer {
 			mock := tsnetpkg.NewMockTSNetServer()
 
 			// Override listen functions to track calls
@@ -143,7 +143,7 @@ func TestFunnelIntegration(t *testing.T) {
 		var listenCalled bool
 
 		// Create mock factory that tracks which listen method is called
-		factory := func() tsnetpkg.TSNetServer {
+		factory := func(serviceName string) tsnetpkg.TSNetServer {
 			mock := tsnetpkg.NewMockTSNetServer()
 
 			// Override listen functions to track calls
@@ -215,7 +215,7 @@ func TestFunnelIntegration(t *testing.T) {
 		var listenCalled bool
 
 		// Create mock factory that tracks which listen method is called
-		factory := func() tsnetpkg.TSNetServer {
+		factory := func(serviceName string) tsnetpkg.TSNetServer {
 			mock := tsnetpkg.NewMockTSNetServer()
 
 			// Override listen functions to track calls


### PR DESCRIPTION
- Add simple tsnet logging adapter that routes all logs to debug level (only visible with -verbose)
- Remove complex log parsing - just use standard printf formatting
- Add service name context to all tsnet logs for better observability
- Update factory functions to pass service names to tsnet servers

This significantly reduces log noise from TSNet's internal operations by hiding all TSNet logs unless the -verbose flag is used. The implementation is kept intentionally simple with no complex parsing or level detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced logging with structured output for both internal and user-facing logs, providing clearer and more informative log messages.

* **Tests**
  * Added comprehensive tests for new logging adapters to ensure correct formatting, log levels, and attribute inclusion.
  * Updated test cases to use the new factory function signature accepting a service name for improved consistency and future extensibility.

* **Refactor**
  * Unified server factory function signatures across the codebase to accept a service name, improving clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->