### PR TITLE
refactor: remove unimplemented connection pool metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -29,8 +29,6 @@ type Collector struct {
 	OAuthRefreshTotal    *prometheus.CounterVec
 	BackendHealth        *prometheus.GaugeVec
 	ConnectionPoolActive *prometheus.GaugeVec
-	ConnectionPoolIdle   *prometheus.GaugeVec
-	ConnectionPoolWait   *prometheus.GaugeVec
 
 	// Service lifecycle metrics
 	ServiceOperations    *prometheus.CounterVec
@@ -101,20 +99,6 @@ func NewCollector() *Collector {
 			},
 			[]string{"service"},
 		),
-		ConnectionPoolIdle: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "tsbridge_connection_pool_idle",
-				Help: "Number of idle connections in the pool",
-			},
-			[]string{"service"},
-		),
-		ConnectionPoolWait: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "tsbridge_connection_pool_wait",
-				Help: "Number of requests waiting for a connection",
-			},
-			[]string{"service"},
-		),
 		ServiceOperations: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "tsbridge_service_operations_total",
@@ -164,8 +148,6 @@ func (c *Collector) Register(reg prometheus.Registerer) error {
 		c.OAuthRefreshTotal,
 		c.BackendHealth,
 		c.ConnectionPoolActive,
-		c.ConnectionPoolIdle,
-		c.ConnectionPoolWait,
 		c.ServiceOperations,
 		c.ServiceOpDuration,
 		c.ServicesActive,
@@ -202,10 +184,8 @@ func (c *Collector) SetBackendHealth(service string, healthy bool) {
 }
 
 // UpdateConnectionPoolMetrics updates connection pool metrics for a service
-func (c *Collector) UpdateConnectionPoolMetrics(service string, active, idle, wait int) {
+func (c *Collector) UpdateConnectionPoolMetrics(service string, active int) {
 	c.ConnectionPoolActive.WithLabelValues(service).Set(float64(active))
-	c.ConnectionPoolIdle.WithLabelValues(service).Set(float64(idle))
-	c.ConnectionPoolWait.WithLabelValues(service).Set(float64(wait))
 }
 
 // RecordServiceOperation records a service lifecycle operation

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -373,15 +373,11 @@ func TestEnhancedMetrics(t *testing.T) {
 	t.Run("ConnectionPoolMetrics", func(t *testing.T) {
 		collector := NewCollector()
 		require.NotNil(t, collector.ConnectionPoolActive)
-		require.NotNil(t, collector.ConnectionPoolIdle)
-		require.NotNil(t, collector.ConnectionPoolWait)
 
 		// Test updating connection pool metrics
-		collector.UpdateConnectionPoolMetrics("test-service", 5, 3, 2)
+		collector.UpdateConnectionPoolMetrics("test-service", 5)
 
 		assert.Equal(t, float64(5), promtestutil.ToFloat64(collector.ConnectionPoolActive.WithLabelValues("test-service")))
-		assert.Equal(t, float64(3), promtestutil.ToFloat64(collector.ConnectionPoolIdle.WithLabelValues("test-service")))
-		assert.Equal(t, float64(2), promtestutil.ToFloat64(collector.ConnectionPoolWait.WithLabelValues("test-service")))
 	})
 
 	t.Run("MetricsRegistration", func(t *testing.T) {
@@ -464,21 +460,17 @@ func TestUpdateConnectionPoolMetrics(t *testing.T) {
 		name    string
 		service string
 		active  int
-		idle    int
-		wait    int
 	}{
-		{"initial metrics", "service1", 10, 5, 2},
-		{"high load", "service2", 50, 0, 10},
-		{"idle pool", "service3", 0, 20, 0},
+		{"initial metrics", "service1", 10},
+		{"high load", "service2", 50},
+		{"idle pool", "service3", 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			collector.UpdateConnectionPoolMetrics(tt.service, tt.active, tt.idle, tt.wait)
+			collector.UpdateConnectionPoolMetrics(tt.service, tt.active)
 
 			assert.Equal(t, float64(tt.active), promtestutil.ToFloat64(collector.ConnectionPoolActive.WithLabelValues(tt.service)))
-			assert.Equal(t, float64(tt.idle), promtestutil.ToFloat64(collector.ConnectionPoolIdle.WithLabelValues(tt.service)))
-			assert.Equal(t, float64(tt.wait), promtestutil.ToFloat64(collector.ConnectionPoolWait.WithLabelValues(tt.service)))
 		})
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -370,7 +370,7 @@ func (h *httpHandler) collectMetrics() {
 	}
 
 	active := int(h.getActiveRequests())
-	h.metricsCollector.UpdateConnectionPoolMetrics(h.serviceName, active, 0, 0)
+	h.metricsCollector.UpdateConnectionPoolMetrics(h.serviceName, active)
 }
 
 // Close stops metrics collection and cleans up resources

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1155,13 +1155,9 @@ func TestConnectionPoolMetricsCollection(t *testing.T) {
 		// Check that connection pool metrics are being collected
 		// We just verify the metric exists and can be read
 		activeMetric := testutil.ToFloat64(collector.ConnectionPoolActive.WithLabelValues("test-service"))
-		idleMetric := testutil.ToFloat64(collector.ConnectionPoolIdle.WithLabelValues("test-service"))
-		waitMetric := testutil.ToFloat64(collector.ConnectionPoolWait.WithLabelValues("test-service"))
 
 		// Metrics should exist (active should be 0 since requests completed)
 		assert.GreaterOrEqual(t, activeMetric, 0.0)
-		assert.Equal(t, 0.0, idleMetric) // We don't track idle
-		assert.Equal(t, 0.0, waitMetric) // We don't track wait
 	})
 
 	t.Run("metrics collector runs periodically", func(t *testing.T) {


### PR DESCRIPTION
- Remove ConnectionPoolIdle and ConnectionPoolWait metrics
- These metrics cannot be implemented without access to http.Transport internals
- Simplify UpdateConnectionPoolMetrics to only track active connections
- Update all tests to reflect the simpler API
- Keep ConnectionPoolActive as it provides useful load information