### PR TITLE
feat: simplify listener configuration to use listen_addr

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -211,8 +211,8 @@ backend_addr = "localhost:8080"
 # TLS mode
 tls_mode = "auto"          # Use Tailscale HTTPS (default) - or "off" for HTTP only
 
-# Custom listen port
-listen_port = "8443"       # Custom port (default: 443 for TLS, 80 for non-TLS)
+# Listening configuration
+listen_addr = "0.0.0.0:8443"  # Listen on specific address and port (default: ":443" for TLS, ":80" for non-TLS)
 ```
 
 ### Tailscale Features

--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -74,6 +74,7 @@ labels:
   - "tsbridge.service.name=custom-name"      # Default: container name
   - "tsbridge.service.whois_enabled=true"    # Add identity headers
   - "tsbridge.service.tags=tag:api,tag:prod" # Override default tags
+  - "tsbridge.service.listen_addr=0.0.0.0:9090" # Custom address and port
 ```
 
 ## Backend Address Tips
@@ -90,6 +91,20 @@ labels:
 **Why?** In Docker, each container has its own network namespace. `localhost` inside tsbridge doesn't reach your service container.
 
 ## Advanced Features
+
+### Custom Listen Configuration
+
+```yaml
+labels:
+  # Listen on specific address and port
+  - "tsbridge.service.listen_addr=127.0.0.1:9090"
+
+  # Listen on all interfaces with custom port
+  - "tsbridge.service.listen_addr=0.0.0.0:8080"
+  
+  # Listen on port only (all interfaces)
+  - "tsbridge.service.listen_addr=:8443"
+```
 
 ### Streaming/SSE
 

--- a/example/simple/tsbridge-custom-ports.toml
+++ b/example/simple/tsbridge-custom-ports.toml
@@ -16,16 +16,22 @@ metrics_addr = ":9090"
 name = "api-https"
 backend_addr = "127.0.0.1:8080"
 tls_mode = "auto"        # HTTPS with automatic certificates
-listen_port = "8443"     # Custom HTTPS port instead of default 443
+listen_addr = ":8443"    # Custom HTTPS port instead of default 443
 
 [[services]]
 name = "api-http"
 backend_addr = "127.0.0.1:8081"
 tls_mode = "off"         # HTTP only (still encrypted via WireGuard)
-listen_port = "8080"     # Custom HTTP port instead of default 80
+listen_addr = ":8080"    # Custom HTTP port instead of default 80
+
+[[services]]
+name = "api-custom-addr"
+backend_addr = "127.0.0.1:8082"
+tls_mode = "auto"        # HTTPS with automatic certificates
+listen_addr = "127.0.0.1:9443"  # Listen on specific address and port
 
 [[services]]
 name = "metrics"
 backend_addr = "127.0.0.1:9100"
 tls_mode = "auto"        # Uses default port 443
-# No listen_port specified, so uses default
+# No listen_addr specified, so uses default ":443"

--- a/internal/config/compare_test.go
+++ b/internal/config/compare_test.go
@@ -55,30 +55,30 @@ func TestServiceConfigEqual(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "different listen ports",
+			name: "different listen addrs",
 			a: Service{
 				Name:        "test-service",
 				BackendAddr: "http://localhost:8080",
-				ListenPort:  "443",
+				ListenAddr:  ":443",
 			},
 			b: Service{
 				Name:        "test-service",
 				BackendAddr: "http://localhost:8080",
-				ListenPort:  "8443",
+				ListenAddr:  ":8443",
 			},
 			expected: false,
 		},
 		{
-			name: "same listen ports",
+			name: "same listen addrs",
 			a: Service{
 				Name:        "test-service",
 				BackendAddr: "http://localhost:8080",
-				ListenPort:  "443",
+				ListenAddr:  ":443",
 			},
 			b: Service{
 				Name:        "test-service",
 				BackendAddr: "http://localhost:8080",
-				ListenPort:  "443",
+				ListenAddr:  ":443",
 			},
 			expected: true,
 		},
@@ -405,7 +405,7 @@ func TestServiceConfigEqualCoversAllFields(t *testing.T) {
 	comparedFields := map[string]bool{
 		"Name":                  true,
 		"BackendAddr":           true,
-		"ListenPort":            true,
+		"ListenAddr":            true,
 		"WhoisEnabled":          true,
 		"WhoisTimeout":          true,
 		"TLSMode":               true,

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -295,7 +295,7 @@ func (p *Provider) parseServiceConfig(container container.Summary) (*config.Serv
 	svc.AccessLog = parser.getBool("service.access_log")
 	svc.FunnelEnabled = parser.getBool("service.funnel_enabled")
 	svc.TLSMode = parser.getString("service.tls_mode")
-	svc.ListenPort = parser.getString("service.listen_port")
+	svc.ListenAddr = parser.getString("service.listen_addr")
 	svc.WhoisTimeout = parser.getDuration("service.whois_timeout")
 	svc.ReadHeaderTimeout = parser.getDuration("service.read_header_timeout")
 	svc.WriteTimeout = parser.getDuration("service.write_timeout")

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -697,7 +697,7 @@ func getDockerParsedServiceFields() map[string]bool {
 		"service.remove_downstream":       true,
 		"service.tags":                    true,
 		"service.max_request_body_size":   true,
-		"service.listen_port":             true,
+		"service.listen_addr":             true,
 	}
 }
 

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -211,13 +211,13 @@ func (s *Server) createServiceListener(serviceServer tsnetpkg.TSNetServer, svc c
 		return s.createFunnelListener(serviceServer, svc.Name, listenStart)
 	}
 
-	listenPort := s.determineListenPort(svc, tlsMode)
+	listenAddr := s.determineListenAddr(svc, tlsMode)
 
 	switch tlsMode {
 	case "auto":
-		return s.createTLSListener(serviceServer, svc.Name, listenPort, listenStart)
+		return s.createTLSListener(serviceServer, svc.Name, listenAddr, listenStart)
 	case "off":
-		return s.createPlainListener(serviceServer, svc.Name, listenPort, listenStart)
+		return s.createPlainListener(serviceServer, svc.Name, listenAddr, listenStart)
 	default:
 		return nil, tserrors.NewValidationError(fmt.Sprintf("invalid TLS mode: %q", tlsMode))
 	}
@@ -245,10 +245,10 @@ func (s *Server) createFunnelListener(serviceServer tsnetpkg.TSNetServer, servic
 }
 
 // createTLSListener creates a TLS listener with certificate priming.
-func (s *Server) createTLSListener(serviceServer tsnetpkg.TSNetServer, serviceName, listenPort string, listenStart time.Time) (net.Listener, error) {
+func (s *Server) createTLSListener(serviceServer tsnetpkg.TSNetServer, serviceName, listenAddr string, listenStart time.Time) (net.Listener, error) {
 	listenerStart := time.Now()
-	slog.Debug("creating TLS listener", "service", serviceName, "address", listenPort)
-	listener, err := serviceServer.ListenTLS("tcp", listenPort)
+	slog.Debug("creating TLS listener", "service", serviceName, "address", listenAddr)
+	listener, err := serviceServer.ListenTLS("tcp", listenAddr)
 	if err != nil {
 		slog.Debug("TLS listener creation failed",
 			"service", serviceName,
@@ -279,10 +279,10 @@ func (s *Server) createTLSListener(serviceServer tsnetpkg.TSNetServer, serviceNa
 }
 
 // createPlainListener creates a plain (non-TLS) listener.
-func (s *Server) createPlainListener(serviceServer tsnetpkg.TSNetServer, serviceName, listenPort string, listenStart time.Time) (net.Listener, error) {
+func (s *Server) createPlainListener(serviceServer tsnetpkg.TSNetServer, serviceName, listenAddr string, listenStart time.Time) (net.Listener, error) {
 	listenerStart := time.Now()
-	slog.Debug("creating plain listener", "service", serviceName, "address", listenPort)
-	listener, err := serviceServer.Listen("tcp", listenPort)
+	slog.Debug("creating plain listener", "service", serviceName, "address", listenAddr)
+	listener, err := serviceServer.Listen("tcp", listenAddr)
 	if err != nil {
 		slog.Debug("plain listener creation failed",
 			"service", serviceName,
@@ -299,8 +299,8 @@ func (s *Server) createPlainListener(serviceServer tsnetpkg.TSNetServer, service
 	return listener, nil
 }
 
-// determineListenPort returns the address to listen on based on service config and TLS mode
-func (s *Server) determineListenPort(svc config.Service, tlsMode string) string {
+// determineListenAddr returns the address to listen on based on service config and TLS mode
+func (s *Server) determineListenAddr(svc config.Service, tlsMode string) string {
 	// Use ListenAddr if set
 	if svc.ListenAddr != "" {
 		return svc.ListenAddr

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -299,11 +299,13 @@ func (s *Server) createPlainListener(serviceServer tsnetpkg.TSNetServer, service
 	return listener, nil
 }
 
-// determineListenPort returns the port to listen on based on service config and TLS mode
+// determineListenPort returns the address to listen on based on service config and TLS mode
 func (s *Server) determineListenPort(svc config.Service, tlsMode string) string {
-	if svc.ListenPort != "" {
-		return ":" + svc.ListenPort
+	// Use ListenAddr if set
+	if svc.ListenAddr != "" {
+		return svc.ListenAddr
 	}
+
 	// Default ports based on TLS mode
 	if tlsMode == "off" {
 		return ":80"

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -1750,24 +1750,6 @@ func TestDetermineListenPort(t *testing.T) {
 			expectedPort: ":80",
 		},
 		{
-			name: "TLS auto with custom port",
-			service: config.Service{
-				Name:       "test",
-				ListenPort: "8443",
-			},
-			tlsMode:      "auto",
-			expectedPort: ":8443",
-		},
-		{
-			name: "TLS off with custom port",
-			service: config.Service{
-				Name:       "test",
-				ListenPort: "8080",
-			},
-			tlsMode:      "off",
-			expectedPort: ":8080",
-		},
-		{
 			name: "Empty TLS mode defaults to auto behavior",
 			service: config.Service{
 				Name: "test",
@@ -1776,13 +1758,31 @@ func TestDetermineListenPort(t *testing.T) {
 			expectedPort: ":443",
 		},
 		{
-			name: "Custom port overrides regardless of TLS mode",
+			name: "ListenAddr with just port",
 			service: config.Service{
 				Name:       "test",
-				ListenPort: "9999",
+				ListenAddr: ":7070",
 			},
-			tlsMode:      "",
-			expectedPort: ":9999",
+			tlsMode:      "auto",
+			expectedPort: ":7070",
+		},
+		{
+			name: "ListenAddr with full address",
+			service: config.Service{
+				Name:       "test",
+				ListenAddr: "0.0.0.0:8888",
+			},
+			tlsMode:      "off",
+			expectedPort: "0.0.0.0:8888",
+		},
+		{
+			name: "ListenAddr with IPv6 address",
+			service: config.Service{
+				Name:       "test",
+				ListenAddr: "[::1]:9090",
+			},
+			tlsMode:      "auto",
+			expectedPort: "[::1]:9090",
 		},
 	}
 

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -1726,7 +1726,7 @@ func TestCloseService(t *testing.T) {
 	}
 }
 
-func TestDetermineListenPort(t *testing.T) {
+func TestDetermineListenAddr(t *testing.T) {
 	tests := []struct {
 		name         string
 		service      config.Service
@@ -1799,7 +1799,7 @@ func TestDetermineListenPort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := server.determineListenPort(tt.service, tt.tlsMode)
+			result := server.determineListenAddr(tt.service, tt.tlsMode)
 			assert.Equal(t, tt.expectedPort, result)
 		})
 	}


### PR DESCRIPTION
Replace separate listen_port field with a single listen_addr field that handles both address and port configuration. This provides more flexibility for binding to specific interfaces.

Changes:
- Use listen_addr for all listener configuration
- Default to ":443" for TLS mode, ":80" for non-TLS mode
- Support formats like ":8080", "127.0.0.1:8080", "[::1]:8080"
- Update Docker labels to use listen_addr
- Update documentation and examples

BREAKING CHANGE: listen_port configuration field has been replaced by listen_addr. Use listen_addr = ":8080" to listen on all interfaces with port 8080, or "127.0.0.1:8080" for a specific interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration and Docker label documentation to replace the `listen_port` option with `listen_addr`, allowing specification of both address and port.
  * Added examples and explanations for the new `listen_addr` format in documentation and example configuration files.

* **New Features**
  * Enhanced service configuration with `listen_addr`, enabling more granular control over listening interfaces and ports.

* **Bug Fixes**
  * Improved validation for service listen addresses, including stricter checks for hostnames and port ranges.

* **Refactor**
  * Replaced all usage of `listen_port` with `listen_addr` throughout the codebase and tests for consistency and improved flexibility.
  * Updated listener creation and related functions to use full listen addresses instead of ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->