### PR TITLE
fix: restore container name matching in Docker self-discovery

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -582,6 +582,16 @@ func (p *Provider) getContainerByID(ctx context.Context, id string) (*container.
 		}
 	}
 
+	for _, c := range containers {
+		for _, name := range c.Names {
+			// Docker container names are prefixed with '/'
+			if strings.TrimPrefix(name, "/") == id {
+				slog.Debug("found container by name", "container", c.ID, "name", name)
+				return &c, nil
+			}
+		}
+	}
+
 	return nil, errors.NewValidationError("container not found")
 }
 


### PR DESCRIPTION
The fix in commit 7a6b739 introduced a regression where containers could only be found by ID prefix, not by name. This broke scenarios where containers use custom hostnames (e.g., --hostname=my-agent).

This change restores the previous behavior by:
- First attempting to match by container ID prefix (fast path)
- Then falling back to matching by container name
- Adding comprehensive tests for both ID and name matching

This ensures compatibility with custom hostnames while maintaining the robustness of the client-side filtering approach.

Fixes container discovery failures when using custom Docker hostnames.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced container lookup to support identifying Docker containers by their names in addition to their IDs.

* **Tests**
  * Added comprehensive tests to verify container lookup behavior by full ID, ID prefix, and container name, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->