### PR TITLE
docs: add default_tags to OAuth docker-compose examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ services:
       - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
       - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
       - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+      - "tsbridge.tailscale.default_tags=tag:server"  # Must match or be owned by your OAuth client's tag
 
   whoami:
     image: traefik/whoami
@@ -110,6 +111,8 @@ volumes:
 ```
 
 See [docs/docker-labels.md](docs/docker-labels.md) for the full label reference.
+
+> **Note**: The `default_tags` must match or be owned by your OAuth client's tag. Individual services can override this with their own `tags` label. See [Tag Ownership and OAuth Security](docs/configuration-reference.md#tag-ownership-and-oauth-security) for setup details.
 
 ## Headscale
 

--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -21,6 +21,7 @@ services:
       - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
       - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
       - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+      - "tsbridge.tailscale.default_tags=tag:server"  # Must match or be owned by your OAuth client's tag
 
   myapp:
     image: myapp:latest
@@ -34,6 +35,8 @@ volumes:
 ```
 
 Your app is now at `https://myapp.<tailnet>.ts.net`
+
+> **Note**: The `default_tags` must match or be owned by your OAuth client's tag. Individual services can override this with their own `tags` label. See [Tag Ownership and OAuth Security](configuration-reference.md#tag-ownership-and-oauth-security) for setup details.
 
 ## How It Works
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -120,6 +120,7 @@ services:
       - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
       - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
       - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+      - "tsbridge.tailscale.default_tags=tag:server"  # Must match or be owned by your OAuth client's tag
 
   myapp:
     image: myapp:latest
@@ -127,6 +128,8 @@ services:
       - "tsbridge.enabled=true"
       - "tsbridge.service.name=myapp"
       - "tsbridge.service.port=8080"
+      # Optional: Override default tags for this service
+      # - "tsbridge.service.tags=tag:api,tag:prod"
 
 volumes:
   tsbridge-state:
@@ -145,6 +148,7 @@ tsbridge -config tsbridge.toml -validate
 - **"services must have at least one tag"**: Add `default_tags` to `[global]` section
 - **"OAuth client ID not set"**: Check your environment variables
 - **Connection timeouts**: For streaming, set `write_timeout = "0s"`
+- **Tag authorization errors**: Ensure tags match or are owned by your OAuth client's tag. See [Tag Ownership and OAuth Security](configuration-reference.md#tag-ownership-and-oauth-security)
 
 ## Next Steps
 


### PR DESCRIPTION
Add missing default_tags directive to docker-compose examples that use OAuth authentication. Also add references to the Tag Ownership and OAuth Security documentation section to help users understand the tag requirements.

- Update README.md docker-compose example with default_tags
- Update quickstart.md docker-compose example with default_tags and tag override comment
- Update docker-labels.md quick example with default_tags
- Add notes explaining tag ownership requirements
- Add troubleshooting entry for tag authorization errors

This is related to #88 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker Compose and service label examples to clarify the use of `default_tags` and their relationship to OAuth client tags.
  * Added notes and references about tag ownership and OAuth security.
  * Expanded troubleshooting guidance for tag authorization errors, including links to relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->