### PR TITLE
fix: respect request context when dialing unix sockets

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -275,7 +275,12 @@ func createProxyTransport(backendAddr string, config *TransportConfig) *http.Tra
 			// Handle unix socket addresses
 			if strings.HasPrefix(backendAddr, "unix://") {
 				socketPath := strings.TrimPrefix(backendAddr, "unix://")
-				return net.Dial("unix", socketPath)
+				// Use DialContext so dialing respects the request context (timeouts/cancellation)
+				d := net.Dialer{
+					Timeout:   config.DialTimeout,
+					KeepAlive: config.KeepAliveTimeout,
+				}
+				return d.DialContext(ctx, "unix", socketPath)
 			}
 			// Regular TCP dial
 			d := net.Dialer{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -277,8 +277,7 @@ func createProxyTransport(backendAddr string, config *TransportConfig) *http.Tra
 				socketPath := strings.TrimPrefix(backendAddr, "unix://")
 				// Use DialContext so dialing respects the request context (timeouts/cancellation)
 				d := net.Dialer{
-					Timeout:   config.DialTimeout,
-					KeepAlive: config.KeepAliveTimeout,
+					Timeout: config.DialTimeout,
 				}
 				return d.DialContext(ctx, "unix", socketPath)
 			}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -263,9 +263,8 @@ func TestUnixSocketDialRespectsContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use an already-expired context to ensure DialContext sees cancellation immediately
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 	defer cancel()
-	time.Sleep(1 * time.Millisecond) // ensure deadline is exceeded
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
- Use net.Dialer.DialContext for unix:// backends so timeouts/cancellation propagate
- Add unit test validating 504 on non-listening unix socket with expired context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to Unix socket backends by ensuring connection attempts respect cancellation and timeout settings.

* **Tests**
  * Added a test to verify that Unix socket connections are promptly canceled when the request context is canceled or times out.
  * Minor update to an existing test for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->