### PR TITLE
fix: unify tls_mode accepted values and behavior

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -22,6 +22,7 @@ Complete reference for all tsbridge configuration options.
 You must provide either OAuth credentials OR an auth key.
 
 > **Resolution Order**: tsbridge resolves secret values in the following priority order:
+>
 > 1. **Direct value** (inline in config file)
 > 2. **File** (from `_file` suffix)
 > 3. **Environment variable** (from `_env` suffix)
@@ -80,7 +81,7 @@ Configure tag ownership in your Tailscale ACL policy:
 ```jsonc
 {
   "tagOwners": {
-    "tag:tsbridge": [],        // Parent tag for OAuth client
+    "tag:tsbridge": [], // Parent tag for OAuth client
     "tag:server": ["tag:tsbridge"],
     "tag:proxy": ["tag:tsbridge"],
     "tag:prod": ["tag:tsbridge"],
@@ -90,6 +91,7 @@ Configure tag ownership in your Tailscale ACL policy:
 ```
 
 In this configuration:
+
 - `tag:tsbridge` is the parent tag for the OAuth client
 - `tag:server`, `tag:proxy`, `tag:prod`, and `tag:dev` are service tags owned by `tag:tsbridge`
 
@@ -209,7 +211,10 @@ backend_addr = "localhost:8080"
 
 ```toml
 # TLS mode
-tls_mode = "auto"          # Use Tailscale HTTPS (default) - or "off" for HTTP only
+# Accepted values: "auto" (default), "off"
+# - "auto": Use Tailscale HTTPS with automatic certificates
+# - "off":  Serve HTTP only (transport still encrypted over WireGuard)
+tls_mode = "auto"
 
 # Listening configuration
 listen_addr = "0.0.0.0:8443"  # Listen on specific address and port (default: ":443" for TLS, ":80" for non-TLS)
@@ -275,6 +280,7 @@ max_request_body_size = "100MB"   # Larger uploads allowed
 ## Environment Variables
 
 Default environment variables checked if no config specified:
+
 - `TS_OAUTH_CLIENT_ID` - OAuth client ID
 - `TS_OAUTH_CLIENT_SECRET` - OAuth client secret
 - `TS_AUTHKEY` - Auth key
@@ -286,17 +292,20 @@ Default environment variables checked if no config specified:
 tsbridge resolves secrets using different modes based on what you specify:
 
 **Direct mode** (when you set a value directly):
+
 ```toml
 oauth_client_id = "k12...89"  # This value is used
 ```
 
 **Environment variable mode** (when you use `_env`):
+
 ```toml
 oauth_client_id_env = "MY_CUSTOM_VAR"  # Reads from MY_CUSTOM_VAR
 # Falls back to TS_OAUTH_CLIENT_ID if MY_CUSTOM_VAR is not set
 ```
 
 **File mode** (when you use `_file`):
+
 ```toml
 oauth_client_id_file = "/path/to/file"  # Reads from file
 # Falls back to TS_OAUTH_CLIENT_ID if file doesn't exist
@@ -305,6 +314,7 @@ oauth_client_id_file = "/path/to/file"  # Reads from file
 **Important**: If you specify `_env` or `_file`, any direct value is ignored. You cannot mix modes.
 
 **Override**: Environment variables prefixed with `TSBRIDGE_` can override any configuration:
+
 - `TSBRIDGE_TAILSCALE_OAUTH_CLIENT_ID` overrides `tailscale.oauth_client_id`
 - `TSBRIDGE_GLOBAL_METRICS_ADDR` overrides `global.metrics_addr`
 
@@ -317,6 +327,7 @@ tsbridge -config tsbridge.toml -validate
 ```
 
 Validates:
+
 - Required fields present
 - No duplicate service names
 - Valid duration formats

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -870,10 +870,10 @@ func (c *Config) validateService(svc *Service) error {
 	// Validate TLS mode (only if set)
 	if svc.TLSMode != "" {
 		switch svc.TLSMode {
-		case "auto", "off":
+		case constants.TLSModeAuto, constants.TLSModeOff:
 			// Valid values
 		default:
-			return errors.NewValidationError(fmt.Sprintf("invalid tls_mode %q: must be 'auto' or 'off'", svc.TLSMode))
+			return errors.NewValidationError(fmt.Sprintf("invalid tls_mode %q: must be '%s' or '%s'", svc.TLSMode, constants.TLSModeAuto, constants.TLSModeOff))
 		}
 	}
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -70,6 +70,14 @@ const (
 	DefaultTLSMode = "auto"
 )
 
+// TLS mode values for services.
+const (
+	// TLSModeAuto enables HTTPS with automatic certificates from Tailscale.
+	TLSModeAuto = "auto"
+	// TLSModeOff disables HTTPS listener and serves plain HTTP (encrypted over WireGuard).
+	TLSModeOff = "off"
+)
+
 // Default size limits used in configuration.
 const (
 	// DefaultMaxRequestBodySize is the default maximum request body size (50 MB).

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -531,7 +531,7 @@ func (r *Registry) RemoveService(name string) error {
 // Validates:
 //   - Non-empty service name and backend address
 //   - Absolute unix socket paths (unix://)
-//   - TLS mode is off, auto, or on
+//   - TLS mode is one of "off" or "auto"
 //   - Non-negative timeouts
 //
 // Returns error if invalid.
@@ -567,10 +567,10 @@ func (r *Registry) validateServiceConfig(cfg config.Service) error {
 
 	// Validate TLS mode
 	switch cfg.TLSMode {
-	case "off", "auto", "on":
+	case constants.TLSModeOff, constants.TLSModeAuto:
 		// Valid modes
 	default:
-		return fmt.Errorf("invalid TLS mode: %s (must be 'off', 'auto', or 'on')", cfg.TLSMode)
+		return fmt.Errorf("invalid TLS mode: %s (must be '%s' or '%s')", cfg.TLSMode, constants.TLSModeOff, constants.TLSModeAuto)
 	}
 
 	// Validate timeout values

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -2448,11 +2448,11 @@ func TestRegistry_AddService_ValidationFailure(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "empty TLS mode",
+			name: "invalid TLS mode",
 			svcCfg: config.Service{
 				Name:        "test-service",
 				BackendAddr: "http://localhost:8080",
-				TLSMode:     "", // Empty TLS mode should be invalid
+				TLSMode:     "on",
 			},
 			wantErr: "invalid TLS mode",
 		},

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -214,9 +214,9 @@ func (s *Server) createServiceListener(serviceServer tsnetpkg.TSNetServer, svc c
 	listenAddr := s.determineListenAddr(svc, tlsMode)
 
 	switch tlsMode {
-	case "auto":
+	case constants.TLSModeAuto:
 		return s.createTLSListener(serviceServer, svc.Name, listenAddr, listenStart)
-	case "off":
+	case constants.TLSModeOff:
 		return s.createPlainListener(serviceServer, svc.Name, listenAddr, listenStart)
 	default:
 		return nil, tserrors.NewValidationError(fmt.Sprintf("invalid TLS mode: %q", tlsMode))


### PR DESCRIPTION
- Add TLS mode constants (auto, off) in internal/constants
- Validate tls_mode using shared constants in config and service
- Ensure tailscale listener handles only supported modes
- Update docs to state exact accepted values and behavior
- Add tests for valid/invalid tls_mode values