### PR TITLE
feat!: add oauth_preauthorized config option

### DIFF
--- a/deployments/freebsd/config.example.toml
+++ b/deployments/freebsd/config.example.toml
@@ -30,6 +30,10 @@ default_tags = ["tag:server", "tag:tsbridge"]
 # Uncomment to use a custom control server like Headscale
 # control_url = "https://headscale.example.com"
 
+# Preauthorize OAuth-generated auth keys (optional - defaults to true)
+# Set to false to require manual approval of devices in the admin console
+# oauth_preauthorized = false
+
 # Global defaults for all services (optional)
 [global]
 # Timeouts

--- a/deployments/freebsd/config.example.toml
+++ b/deployments/freebsd/config.example.toml
@@ -32,6 +32,7 @@ default_tags = ["tag:server", "tag:tsbridge"]
 
 # Preauthorize OAuth-generated auth keys (optional - defaults to true)
 # Set to false to require manual approval of devices in the admin console
+# Can be overridden per-service via [[services]].oauth_preauthorized
 # oauth_preauthorized = false
 
 # Global defaults for all services (optional)

--- a/deployments/systemd/README.md
+++ b/deployments/systemd/README.md
@@ -43,6 +43,7 @@ TS_OAUTH_CLIENT_SECRET=your-client-secret
 # OAuth credentials come from environment
 state_dir = "/var/lib/tsbridge"  # Or omit - systemd sets STATE_DIRECTORY
 default_tags = ["tag:server"]
+# oauth_preauthorized = false  # Require manual device approval (default: true)
 
 [global]
 metrics_addr = ":9090"

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -67,6 +67,10 @@ default_tags = ["tag:server", "tag:proxy"]
 
 # Control server URL (for Headscale or custom servers)
 control_url = "https://headscale.example.com"
+
+# Preauthorize OAuth-generated auth keys (optional - defaults to true)
+# Set to false to require manual approval of devices in the admin console
+oauth_preauthorized = false
 ```
 
 ### Tag Ownership and OAuth Security

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -70,6 +70,8 @@ control_url = "https://headscale.example.com"
 
 # Preauthorize OAuth-generated auth keys (optional - defaults to true)
 # Set to false to require manual approval of devices in the admin console
+# Can be overridden per-service: set [[services]].oauth_preauthorized = false
+# Breaking change: Default is now true; set to false if you require manual approval.
 oauth_preauthorized = false
 ```
 

--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -58,7 +58,7 @@ labels:
   
   # Optional: defaults
   - "tsbridge.tailscale.default_tags=tag:server,tag:proxy"
-  - "tsbridge.tailscale.oauth_preauthorized=false"  # Require manual device approval
+  - "tsbridge.tailscale.oauth_preauthorized=false"  # Require manual device approval (default: true)
   - "tsbridge.global.metrics_addr=:9090"
   - "tsbridge.global.write_timeout=30s"
 ```
@@ -78,7 +78,7 @@ labels:
   - "tsbridge.service.name=custom-name"      # Default: container name
   - "tsbridge.service.whois_enabled=true"    # Add identity headers
   - "tsbridge.service.tags=tag:api,tag:prod" # Override default tags
-  - "tsbridge.service.oauth_preauthorized=false"  # Override global preauth setting
+  - "tsbridge.service.oauth_preauthorized=false"  # Override global preauth setting (global default: true)
   - "tsbridge.service.listen_addr=0.0.0.0:9090" # Custom address and port
 ```
 

--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -58,6 +58,7 @@ labels:
   
   # Optional: defaults
   - "tsbridge.tailscale.default_tags=tag:server,tag:proxy"
+  - "tsbridge.tailscale.oauth_preauthorized=false"  # Require manual device approval
   - "tsbridge.global.metrics_addr=:9090"
   - "tsbridge.global.write_timeout=30s"
 ```
@@ -77,6 +78,7 @@ labels:
   - "tsbridge.service.name=custom-name"      # Default: container name
   - "tsbridge.service.whois_enabled=true"    # Add identity headers
   - "tsbridge.service.tags=tag:api,tag:prod" # Override default tags
+  - "tsbridge.service.oauth_preauthorized=false"  # Override global preauth setting
   - "tsbridge.service.listen_addr=0.0.0.0:9090" # Custom address and port
 ```
 

--- a/example/simple/tsbridge.toml
+++ b/example/simple/tsbridge.toml
@@ -12,6 +12,7 @@ default_tags = ["tag:tsbridge", "tag:proxy"]
 # control_url = "https://headscale.example.com"
 # Preauthorize OAuth-generated auth keys (optional - defaults to true)
 # Set to false to require manual approval of devices in the admin console
+# Can be overridden per-service via [[services]].oauth_preauthorized
 # oauth_preauthorized = false
 
 [global]

--- a/example/simple/tsbridge.toml
+++ b/example/simple/tsbridge.toml
@@ -10,6 +10,9 @@ default_tags = ["tag:tsbridge", "tag:proxy"]
 # Control server URL (optional - defaults to Tailscale's control servers)
 # Uncomment to use a custom control server like Headscale
 # control_url = "https://headscale.example.com"
+# Preauthorize OAuth-generated auth keys (optional - defaults to true)
+# Set to false to require manual approval of devices in the admin console
+# oauth_preauthorized = false
 
 [global]
 
@@ -80,3 +83,10 @@ backend_addr = "api-backend:8080"
 whois_enabled = true
 max_request_body_size = "-1"      # Disable body size limit (-1 means no limit)
 write_timeout = "600s"            # Very long timeout for unlimited uploads
+
+# Example of a service that requires manual device approval
+[[services]]
+name = "demo-secure"
+backend_addr = "api-backend:8080"
+whois_enabled = true
+oauth_preauthorized = false       # Override global setting - require manual approval

--- a/internal/config/compare_test.go
+++ b/internal/config/compare_test.go
@@ -139,6 +139,48 @@ func TestServiceConfigEqual(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "different oauth preauthorized setting",
+			a: Service{
+				Name:               "test-service",
+				BackendAddr:        "http://localhost:8080",
+				OAuthPreauthorized: boolPtr(true),
+			},
+			b: Service{
+				Name:               "test-service",
+				BackendAddr:        "http://localhost:8080",
+				OAuthPreauthorized: boolPtr(false),
+			},
+			expected: false,
+		},
+		{
+			name: "nil vs non-nil oauth preauthorized",
+			a: Service{
+				Name:               "test-service",
+				BackendAddr:        "http://localhost:8080",
+				OAuthPreauthorized: nil,
+			},
+			b: Service{
+				Name:               "test-service",
+				BackendAddr:        "http://localhost:8080",
+				OAuthPreauthorized: boolPtr(false),
+			},
+			expected: false,
+		},
+		{
+			name: "both nil oauth preauthorized",
+			a: Service{
+				Name:               "test-service",
+				BackendAddr:        "http://localhost:8080",
+				OAuthPreauthorized: nil,
+			},
+			b: Service{
+				Name:               "test-service",
+				BackendAddr:        "http://localhost:8080",
+				OAuthPreauthorized: nil,
+			},
+			expected: true,
+		},
+		{
 			name: "different ephemeral setting",
 			a: Service{
 				Name:        "test-service",

--- a/internal/config/compare_test.go
+++ b/internal/config/compare_test.go
@@ -423,6 +423,7 @@ func TestServiceConfigEqualCoversAllFields(t *testing.T) {
 		"RemoveUpstream":        true,
 		"RemoveDownstream":      true,
 		"MaxRequestBodySize":    true,
+		"OAuthPreauthorized":    true,
 	}
 
 	// Check that all struct fields are in our comparison

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type Tailscale struct {
 	StateDirEnv           string         `mapstructure:"state_dir_env"`            // Env var containing state directory
 	DefaultTags           []string       `mapstructure:"default_tags"`             // Default tags for services
 	ControlURL            string         `mapstructure:"control_url"`              // Control server URL (e.g., for Headscale)
+	OAuthPreauthorized    *bool          `mapstructure:"oauth_preauthorized"`      // Preauthorize OAuth-generated auth keys (default: true)
 }
 
 // Global contains global default settings
@@ -84,6 +85,7 @@ type Service struct {
 	MaxRequestBodySize    *int64         `mapstructure:"max_request_body_size"`   // Override global max request body size
 	FunnelEnabled         *bool          `mapstructure:"funnel_enabled"`          // Expose service via Tailscale Funnel
 	Ephemeral             bool           `mapstructure:"ephemeral"`               // Create ephemeral nodes
+	OAuthPreauthorized    *bool          `mapstructure:"oauth_preauthorized"`     // Override global OAuth preauthorized setting
 	FlushInterval         *time.Duration `mapstructure:"flush_interval"`          // Time between flushes (-1ms for immediate)
 	// Header manipulation
 	UpstreamHeaders   map[string]string `mapstructure:"upstream_headers"`   // Headers to add to upstream requests
@@ -501,6 +503,12 @@ func (c *Config) SetDefaults() {
 	if c.Global.MetricsReadHeaderTimeout == nil {
 		defaultTimeout := constants.DefaultMetricsReadHeaderTimeout
 		c.Global.MetricsReadHeaderTimeout = &defaultTimeout
+	}
+
+	// Set Tailscale defaults
+	if c.Tailscale.OAuthPreauthorized == nil {
+		defaultPreauth := true
+		c.Tailscale.OAuthPreauthorized = &defaultPreauth
 	}
 
 	// Set service defaults

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2096,7 +2096,7 @@ func TestOAuthPreauthorizedConfiguration(t *testing.T) {
 	// Test service-level override
 	t.Run("service override takes precedence", func(t *testing.T) {
 		globalTrue := true
-		servicefalse := false
+		serviceFalse := false
 		cfg := &Config{
 			Tailscale: Tailscale{
 				OAuthPreauthorized: &globalTrue, // Global setting is true
@@ -2104,7 +2104,7 @@ func TestOAuthPreauthorizedConfiguration(t *testing.T) {
 			Services: []Service{
 				{
 					Name:               "test-service",
-					OAuthPreauthorized: &servicefalse, // Service overrides to false
+					OAuthPreauthorized: &serviceFalse, // Service overrides to false
 				},
 			},
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2069,6 +2069,57 @@ func TestAccessLoggingConfiguration(t *testing.T) {
 	})
 }
 
+func TestOAuthPreauthorizedConfiguration(t *testing.T) {
+	// Test SetDefaults sets oauth_preauthorized to true
+	t.Run("default oauth preauthorized enabled", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.SetDefaults()
+
+		assert.NotNil(t, cfg.Tailscale.OAuthPreauthorized)
+		assert.True(t, *cfg.Tailscale.OAuthPreauthorized)
+	})
+
+	// Test explicit false is preserved
+	t.Run("explicit false preserved", func(t *testing.T) {
+		preauthorizedFalse := false
+		cfg := &Config{
+			Tailscale: Tailscale{
+				OAuthPreauthorized: &preauthorizedFalse,
+			},
+		}
+		cfg.SetDefaults()
+
+		assert.NotNil(t, cfg.Tailscale.OAuthPreauthorized)
+		assert.False(t, *cfg.Tailscale.OAuthPreauthorized)
+	})
+
+	// Test service-level override
+	t.Run("service override takes precedence", func(t *testing.T) {
+		globalTrue := true
+		servicefalse := false
+		cfg := &Config{
+			Tailscale: Tailscale{
+				OAuthPreauthorized: &globalTrue, // Global setting is true
+			},
+			Services: []Service{
+				{
+					Name:               "test-service",
+					OAuthPreauthorized: &servicefalse, // Service overrides to false
+				},
+			},
+		}
+		cfg.SetDefaults()
+
+		// Global should remain true
+		assert.NotNil(t, cfg.Tailscale.OAuthPreauthorized)
+		assert.True(t, *cfg.Tailscale.OAuthPreauthorized)
+
+		// Service should be false (override)
+		assert.NotNil(t, cfg.Services[0].OAuthPreauthorized)
+		assert.False(t, *cfg.Services[0].OAuthPreauthorized)
+	})
+}
+
 func TestFunnelEnabledConfiguration(t *testing.T) {
 	// Test funnel enabled config can be loaded
 	t.Run("service with funnel enabled", func(t *testing.T) {

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -211,6 +211,7 @@ func (p *Provider) parseGlobalConfig(container *container.Summary, cfg *config.C
 		StateDirEnv:           parser.getString("tailscale.state_dir_env"),
 		DefaultTags:           parser.getStringSlice("tailscale.default_tags", ","),
 		ControlURL:            parser.getString("tailscale.control_url"),
+		OAuthPreauthorized:    parser.getBool("tailscale.oauth_preauthorized"),
 	}
 
 	// Parse global configuration
@@ -307,6 +308,7 @@ func (p *Provider) parseServiceConfig(container container.Summary) (*config.Serv
 	svc.RemoveUpstream = parser.getStringSlice("service.remove_upstream", ",")
 	svc.RemoveDownstream = parser.getStringSlice("service.remove_downstream", ",")
 	svc.MaxRequestBodySize = parser.getByteSize("service.max_request_body_size")
+	svc.OAuthPreauthorized = parser.getBool("service.oauth_preauthorized")
 
 	// Handle ephemeral (non-pointer bool)
 	if ephemeral := parser.getBool("service.ephemeral"); ephemeral != nil {

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -697,6 +697,7 @@ func getDockerParsedServiceFields() map[string]bool {
 		"service.remove_downstream":       true,
 		"service.tags":                    true,
 		"service.max_request_body_size":   true,
+		"service.oauth_preauthorized":     true,
 		"service.listen_addr":             true,
 	}
 }
@@ -718,6 +719,7 @@ func getDockerParsedTailscaleFields() map[string]bool {
 		"tailscale.state_dir_env":            true,
 		"tailscale.default_tags":             true,
 		"tailscale.control_url":              true,
+		"tailscale.oauth_preauthorized":      true,
 	}
 }
 
@@ -742,4 +744,88 @@ func TestDockerControlURLParsing(t *testing.T) {
 
 	assert.Equal(t, "https://headscale.example.com", cfg.Tailscale.ControlURL)
 	assert.Equal(t, "test-client-id", cfg.Tailscale.OAuthClientID)
+}
+
+func TestDockerOAuthPreauthorizedParsing(t *testing.T) {
+	provider := &Provider{
+		labelPrefix: "tsbridge",
+	}
+
+	tests := []struct {
+		name          string
+		labelValue    string
+		expected      *bool
+	}{
+		{"true", "true", func() *bool { b := true; return &b }()},
+		{"false", "false", func() *bool { b := false; return &b }()},
+		{"empty", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := map[string]string{}
+			if tt.labelValue != "" {
+				labels["tsbridge.tailscale.oauth_preauthorized"] = tt.labelValue
+			}
+
+			container := &container.Summary{
+				Names:  []string{"/tsbridge"},
+				Labels: labels,
+			}
+
+			cfg := &config.Config{}
+			err := provider.parseGlobalConfig(container, cfg)
+			require.NoError(t, err)
+
+			if tt.expected == nil {
+				assert.Nil(t, cfg.Tailscale.OAuthPreauthorized)
+			} else {
+				require.NotNil(t, cfg.Tailscale.OAuthPreauthorized)
+				assert.Equal(t, *tt.expected, *cfg.Tailscale.OAuthPreauthorized)
+			}
+		})
+	}
+}
+
+func TestDockerServiceOAuthPreauthorizedParsing(t *testing.T) {
+	provider := &Provider{
+		labelPrefix: "tsbridge",
+	}
+
+	tests := []struct {
+		name          string
+		labelValue    string
+		expected      *bool
+	}{
+		{"true", "true", func() *bool { b := true; return &b }()},
+		{"false", "false", func() *bool { b := false; return &b }()},
+		{"empty", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := map[string]string{
+				"tsbridge.enabled": "true",
+			}
+			if tt.labelValue != "" {
+				labels["tsbridge.service.oauth_preauthorized"] = tt.labelValue
+			}
+
+			container := &container.Summary{
+				Names:  []string{"/test-service"},
+				Labels: labels,
+			}
+
+			svc, err := provider.parseServiceConfig(container)
+			require.NoError(t, err)
+			require.NotNil(t, svc)
+
+			if tt.expected == nil {
+				assert.Nil(t, svc.OAuthPreauthorized)
+			} else {
+				require.NotNil(t, svc.OAuthPreauthorized)
+				assert.Equal(t, *tt.expected, *svc.OAuthPreauthorized)
+			}
+		})
+	}
 }

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -805,7 +805,8 @@ func TestDockerServiceOAuthPreauthorizedParsing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			labels := map[string]string{
-				"tsbridge.enabled": "true",
+				"tsbridge.enabled":      "true",
+				"tsbridge.service.port": "8080",
 			}
 			if tt.labelValue != "" {
 				labels["tsbridge.service.oauth_preauthorized"] = tt.labelValue

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -752,9 +752,9 @@ func TestDockerOAuthPreauthorizedParsing(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		labelValue    string
-		expected      *bool
+		name       string
+		labelValue string
+		expected   *bool
 	}{
 		{"true", "true", func() *bool { b := true; return &b }()},
 		{"false", "false", func() *bool { b := false; return &b }()},
@@ -793,9 +793,9 @@ func TestDockerServiceOAuthPreauthorizedParsing(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		labelValue    string
-		expected      *bool
+		name       string
+		labelValue string
+		expected   *bool
 	}{
 		{"true", "true", func() *bool { b := true; return &b }()},
 		{"false", "false", func() *bool { b := false; return &b }()},
@@ -811,7 +811,7 @@ func TestDockerServiceOAuthPreauthorizedParsing(t *testing.T) {
 				labels["tsbridge.service.oauth_preauthorized"] = tt.labelValue
 			}
 
-			container := &container.Summary{
+			container := container.Summary{
 				Names:  []string{"/test-service"},
 				Labels: labels,
 			}


### PR DESCRIPTION
Add new configuration option to control whether OAuth-generated auth keys are preauthorized. Supports both global and per-service overrides with Docker label configuration.

BREAKING CHANGE: OAuth-generated auth keys are now preauthorized by default. Users who need manual device approval must set oauth_preauthorized=false.

- Add OAuthPreauthorized field to Tailscale and Service config structs
- Update OAuth implementation to use preauthorized setting with service override logic
- Add Docker label support for tailscale.oauth_preauthorized and service.oauth_preauthorized
- Update documentation and example configs to show new option
- Add comprehensive test coverage for all configuration paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added oauth_preauthorized setting to control preauthorization of OAuth-generated auth keys (default: true) with per-service override.

* **Documentation**
  * Updated configuration reference, deployment examples, Docker label examples, and sample config to document the new global and per-service option and manual-approval behavior when disabled.

* **Tests**
  * Added tests for defaulting, per-service precedence, Docker label parsing, and the OAuth preauthorized flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->