### PR TITLE
fix: prevent shutdown hanging during tsnet authentication

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -217,19 +217,24 @@ func (a *App) performShutdown(ctx context.Context) error {
 	// Shutdown services
 	if err := a.registry.Shutdown(ctx); err != nil {
 		// The error from Shutdown is already typed
+		slog.Error("failed to shutdown services", "error", err)
 		errs = append(errs, err)
 	}
 
 	// Shutdown metrics server if running
 	if a.metricsServer != nil {
 		if err := a.metricsServer.Shutdown(ctx); err != nil {
-			errs = append(errs, tserrors.WrapInternal(err, "failed to shutdown metrics server"))
+			wrappedErr := tserrors.WrapInternal(err, "failed to shutdown metrics server")
+			slog.Error("failed to shutdown metrics server", "error", err)
+			errs = append(errs, wrappedErr)
 		}
 	}
 
 	// Close tailscale server
 	if err := a.tsServer.Close(); err != nil {
-		errs = append(errs, tserrors.WrapResource(err, "failed to close tailscale server"))
+		wrappedErr := tserrors.WrapResource(err, "failed to close tailscale server")
+		slog.Error("failed to close tailscale server", "error", err)
+		errs = append(errs, wrappedErr)
 	}
 
 	if len(errs) == 0 {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -160,6 +160,9 @@ const (
 
 	// TsnetServerStartTimeout is the timeout for starting a tsnet server.
 	TsnetServerStartTimeout = 5 * time.Second
+
+	// TSNetServerCloseTimeout is the timeout for closing a tsnet server gracefully.
+	TSNetServerCloseTimeout = 3 * time.Second
 )
 
 // Retry configuration constants.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -161,8 +161,8 @@ const (
 	// TsnetServerStartTimeout is the timeout for starting a tsnet server.
 	TsnetServerStartTimeout = 5 * time.Second
 
-	// TSNetServerCloseTimeout is the timeout for closing a tsnet server gracefully.
-	TSNetServerCloseTimeout = 3 * time.Second
+	// TsnetServerCloseTimeout is the timeout for closing a tsnet server gracefully.
+	TsnetServerCloseTimeout = 3 * time.Second
 )
 
 // Retry configuration constants.

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -378,9 +378,9 @@ func (s *Server) CloseService(serviceName string) error {
 		return nil
 	}
 
-	// Close the tsnet server
-	if err := server.Close(); err != nil {
-		return tserrors.WrapResource(err, fmt.Sprintf("closing tsnet server for service %q", serviceName))
+	// Close the tsnet server with timeout to avoid hangs
+	if err := s.closeServerWithTimeout(server, serviceName, 3*time.Second); err != nil {
+		return err
 	}
 
 	// Remove from the map

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -332,7 +332,7 @@ func (s *Server) Close() error {
 	// Close all service servers with timeout
 	for serviceName, server := range servers {
 		slog.Debug("closing tsnet server", "service", serviceName)
-		if err := s.closeServerWithTimeout(server, serviceName, constants.TSNetServerCloseTimeout); err != nil {
+		if err := s.closeServerWithTimeout(server, serviceName, constants.TsnetServerCloseTimeout); err != nil {
 			closeErrors = append(closeErrors, err)
 		}
 	}
@@ -380,7 +380,7 @@ func (s *Server) CloseService(serviceName string) error {
 	s.mu.Unlock()
 
 	// Close the tsnet server with timeout to avoid hangs
-	if err := s.closeServerWithTimeout(server, serviceName, constants.TSNetServerCloseTimeout); err != nil {
+	if err := s.closeServerWithTimeout(server, serviceName, constants.TsnetServerCloseTimeout); err != nil {
 		return err
 	}
 

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -332,7 +332,7 @@ func (s *Server) Close() error {
 	// Close all service servers with timeout
 	for serviceName, server := range servers {
 		slog.Debug("closing tsnet server", "service", serviceName)
-		if err := s.closeServerWithTimeout(server, serviceName, 3*time.Second); err != nil {
+		if err := s.closeServerWithTimeout(server, serviceName, constants.TSNetServerCloseTimeout); err != nil {
 			closeErrors = append(closeErrors, err)
 		}
 	}
@@ -380,7 +380,7 @@ func (s *Server) CloseService(serviceName string) error {
 	s.mu.Unlock()
 
 	// Close the tsnet server with timeout to avoid hangs
-	if err := s.closeServerWithTimeout(server, serviceName, 3*time.Second); err != nil {
+	if err := s.closeServerWithTimeout(server, serviceName, constants.TSNetServerCloseTimeout); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes TestE2EGracefulShutdown failing in CI when tsnet servers are in the middle of authentication during shutdown.

- Add error logging during shutdown to improve debugging
- Implement 3-second timeout for tsnet server close operations
- Add debug logging to track shutdown progress
- Prevent indefinite hanging when tsnet.Close() blocks

Resolves the build failure where shutdown complete message was not appearing due to hanging tsnet authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents shutdown hangs by enforcing timeouts on individual service closes and returning aggregated errors.
  * Ensures overall shutdown proceeds even if some services are unresponsive.

* **Chores**
  * Adds explicit per-service close timeouts and improves logging for clearer shutdown diagnostics.
  * Aggregates and preserves error information while reporting failures during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->