### PR TITLE
fix: allow underscores in backend hostnames

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -804,11 +804,15 @@ func ValidateBackendAddress(addr string) error {
 }
 
 // isValidHostname performs basic hostname validation
+// Allows alphanumeric characters, hyphens, and underscores in the middle of labels.
+// Labels must start and end with alphanumeric characters.
+// This is more permissive than strict RFC 1123 to support Docker container names
+// and internal service names that may contain underscores.
 func isValidHostname(host string) bool {
 	if host == "" {
 		return false
 	}
-	// Basic hostname validation - RFC 1123
+	// Basic hostname validation - RFC 1123 with extensions for internal names
 	if len(host) > 253 {
 		return false
 	}
@@ -826,9 +830,9 @@ func isValidHostname(host string) bool {
 		if !isAlphaNum(label[len(label)-1]) {
 			return false
 		}
-		// Check all characters
+		// Middle characters can be alphanumeric, hyphen, or underscore
 		for _, ch := range label {
-			if !isAlphaNum(byte(ch)) && ch != '-' {
+			if !isAlphaNum(byte(ch)) && ch != '-' && ch != '_' {
 				return false
 			}
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3404,6 +3404,26 @@ func TestValidateBackendAddress(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid hostname with underscore in middle (Docker container)",
+			addr:    "immich_server:2283",
+			wantErr: false,
+		},
+		{
+			name:    "valid hostname with multiple underscores",
+			addr:    "my_app_server:8080",
+			wantErr: false,
+		},
+		{
+			name:    "valid hostname with hyphen in middle",
+			addr:    "my-app-server:8080",
+			wantErr: false,
+		},
+		{
+			name:    "valid hostname with underscore and hyphen",
+			addr:    "my_app-server:8080",
+			wantErr: false,
+		},
+		{
 			name:    "valid high port",
 			addr:    "0.0.0.0:65535",
 			wantErr: false,


### PR DESCRIPTION
Docker container names and internal service names commonly use underscores, which were being rejected by hostname validation.

Updated isValidHostname to allow underscores and hyphens in the middle of hostname labels while maintaining validation that labels must start and end with alphanumeric characters. This is more permissive than strict RFC 1123 but appropriate for internal backend addresses.

- Allow underscores in middle of hostname labels
- Maintain requirement for alphanumeric start/end
- Add comprehensive test cases for underscore/hyphen combinations
- Document extended validation rules

Fixes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Backend address validation now accepts hostnames with underscores in the middle of labels, reducing false validation errors in internal environments (e.g., container-based setups).
  - Maintains requirement that labels start and end with alphanumeric characters.

- Tests
  - Added test cases to verify acceptance of hostnames with underscores, multiple underscores, hyphens, and mixed underscore-hyphen patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->