### PR TITLE
chore: migrate goreleaser to dockers_v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,68 +30,28 @@ archives:
       - LICENSE
       - README.md
 
-dockers:
-  - image_templates:
-      - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-amd64"
-      - "ghcr.io/jtdowney/tsbridge:latest-amd64"
-      - "ghcr.io/jtdowney/tsbridge:v{{ .Major }}.{{ .Minor }}-amd64"
+dockers_v2:
+  - id: tsbridge
+    images:
+      - ghcr.io/jtdowney/tsbridge
+    tags:
+      - "{{ .Tag }}"
+      - "v{{ .Major }}.{{ .Minor }}"
+      - latest
       # TODO: Uncomment for 1.0.0 release
-      # - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-amd64"
-    dockerfile: Dockerfile
-    goos: linux
-    goarch: amd64
-    use: buildx
-    skip_push: "{{ if .IsSnapshot }}true{{ else }}false{{ end }}"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=Tailscale-based reverse proxy manager"
-      - "--label=org.opencontainers.image.url=https://github.com/jtdowney/tsbridge"
-      - "--label=org.opencontainers.image.source=https://github.com/jtdowney/tsbridge"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-  - image_templates:
-      - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-arm64"
-      - "ghcr.io/jtdowney/tsbridge:latest-arm64"
-      - "ghcr.io/jtdowney/tsbridge:v{{ .Major }}.{{ .Minor }}-arm64"
-      # TODO: Uncomment for 1.0.0 release
-      # - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-arm64"
-    dockerfile: Dockerfile
-    goos: linux
-    goarch: arm64
-    use: buildx
-    skip_push: "{{ if .IsSnapshot }}true{{ else }}false{{ end }}"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=Tailscale-based reverse proxy manager"
-      - "--label=org.opencontainers.image.url=https://github.com/jtdowney/tsbridge"
-      - "--label=org.opencontainers.image.source=https://github.com/jtdowney/tsbridge"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-
-docker_manifests:
-  - name_template: "ghcr.io/jtdowney/tsbridge:{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-amd64"
-      - "ghcr.io/jtdowney/tsbridge:{{ .Tag }}-arm64"
-  - name_template: "ghcr.io/jtdowney/tsbridge:v{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/jtdowney/tsbridge:v{{ .Major }}.{{ .Minor }}-amd64"
-      - "ghcr.io/jtdowney/tsbridge:v{{ .Major }}.{{ .Minor }}-arm64"
-  # TODO: Uncomment for 1.0.0 release
-  # - name_template: "ghcr.io/jtdowney/tsbridge:{{ .Major }}"
-  #   image_templates:
-  #     - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-amd64"
-  #     - "ghcr.io/jtdowney/tsbridge:{{ .Major }}-arm64"
-  - name_template: "ghcr.io/jtdowney/tsbridge:latest"
-    image_templates:
-      - "ghcr.io/jtdowney/tsbridge:latest-amd64"
-      - "ghcr.io/jtdowney/tsbridge:latest-arm64"
+      # - "{{ .Major }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: Tailscale-based reverse proxy manager
+      org.opencontainers.image.url: https://github.com/jtdowney/tsbridge
+      org.opencontainers.image.source: https://github.com/jtdowney/tsbridge
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: MIT
 
 checksum:
   name_template: 'checksums.txt'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.22
 
+ARG TARGETPLATFORM
 RUN apk --no-cache add ca-certificates
-COPY tsbridge /usr/local/bin/tsbridge
+COPY ${TARGETPLATFORM}/tsbridge /usr/local/bin/tsbridge
 EXPOSE 9090
 ENTRYPOINT ["/usr/local/bin/tsbridge"]


### PR DESCRIPTION
Replace deprecated dockers and docker_manifests configuration with the new dockers_v2 format introduced in GoReleaser v2.12. This simplifies multi-arch Docker image builds by using a single docker buildx command.

Update Dockerfile to use TARGETPLATFORM ARG for the new build context structure where binaries are placed in platform-specific subdirectories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Consolidated Docker image build configuration for multi-platform support (amd64, arm64)
  * Enhanced container image metadata with OCI-standard labels for better image identification
  * Optimized platform-specific binary handling in container builds

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->