### PR TITLE
fix: add http.Flusher support to body limit middleware

### DIFF
--- a/internal/middleware/bodylimit.go
+++ b/internal/middleware/bodylimit.go
@@ -80,3 +80,10 @@ func (w *maxBytesResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 	return hijacker.Hijack()
 }
+
+// Flush implements the http.Flusher interface for streaming support
+func (w *maxBytesResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}


### PR DESCRIPTION
Implements Flush() on maxBytesResponseWriter to enable streaming responses through the body limit middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Body limit middleware now properly supports streaming responses with flushing capability.

* **Tests**
  * Added test to verify streaming behavior is preserved when using body limit middleware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->