### PR TITLE
fix: close idle transport connections on handler close

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -391,6 +391,12 @@ func (h *httpHandler) Close() error {
 	if h.stopMetrics != nil {
 		close(h.stopMetrics)
 	}
+
+	// Close idle transport connections to prevent lingering after handler shutdown
+	if h.transport != nil {
+		h.transport.CloseIdleConnections()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Call transport.CloseIdleConnections() in Close() to properly clean up idle HTTP connections when a proxy handler is shut down.

- Add cleanup call in httpHandler.Close()
- Add tests for cleanup with transport set and nil transport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior by ensuring idle transport connections are properly closed during service termination, preventing lingering connections.

* **Tests**
  * Added tests to verify proper transport cleanup during shutdown and validate robustness when transport connections are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->