### PR TITLE
fix: handle nil TransportConfig in NewHandler

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -115,8 +115,12 @@ func NewHandler(cfg *HandlerConfig) (Handler, error) {
 	originalDirector := h.proxy.Director
 	h.proxy.Director = createProxyDirector(h, originalDirector)
 
-	// Configure transport
-	h.transport = createProxyTransport(cfg.BackendAddr, cfg.TransportConfig, cfg.InsecureSkipVerify)
+	// Configure transport (default to empty config if nil)
+	transportConfig := cfg.TransportConfig
+	if transportConfig == nil {
+		transportConfig = &TransportConfig{}
+	}
+	h.transport = createProxyTransport(cfg.BackendAddr, transportConfig, cfg.InsecureSkipVerify)
 	h.proxy.Transport = h.transport
 
 	// Configure ModifyResponse to handle downstream headers


### PR DESCRIPTION
Default to empty TransportConfig when cfg.TransportConfig is nil to prevent potential nil pointer dereference during handler creation.

- Add nil check with default in NewHandler
- Add test verifying handler creation with nil TransportConfig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy handler robustness to gracefully handle edge cases where configuration is not explicitly provided, preventing potential failures and ensuring stable request processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->