### PR TITLE
fix: add timeout to OAuth HTTP operations

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -175,6 +175,11 @@ const (
 	// (token exchange and API calls). This prevents indefinite hangs when
 	// the Tailscale API is unresponsive.
 	OAuthHTTPTimeout = 30 * time.Second
+
+	// OAuthRetryMaxElapsedTime is the maximum total time for all OAuth retry attempts.
+	// This is longer than the general RetryMaxElapsedTime to accommodate the longer
+	// OAuthHTTPTimeout per attempt (30s * 3 attempts + backoff delays).
+	OAuthRetryMaxElapsedTime = 100 * time.Second
 )
 
 // Retry configuration constants.

--- a/internal/tailscale/oauth.go
+++ b/internal/tailscale/oauth.go
@@ -65,7 +65,7 @@ func generateAuthKeyWithOAuth(oauthConfig *oauth2.Config, apiBaseURL string, tag
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = constants.RetryInitialInterval
 	b.MaxInterval = constants.RetryMaxInterval
-	b.MaxElapsedTime = constants.RetryMaxElapsedTime
+	b.MaxElapsedTime = constants.OAuthRetryMaxElapsedTime
 	b.Multiplier = constants.RetryMultiplier
 	b.RandomizationFactor = constants.RetryRandomizationFactor
 


### PR DESCRIPTION
Replace context.Background() with a 30-second timeout context in generateAuthKeyWithOAuthDirect to prevent indefinite blocking when the Tailscale API is unresponsive.

- Add OAuthHTTPTimeout constant (30s) to internal/constants/constants.go
- Apply timeout context to generateAuthKeyWithOAuthDirect
- Context deadline propagates to both token exchange and API calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection to OAuth authentication: a per-request HTTP timeout and a capped total retry window for OAuth operations. These limits prevent indefinite waits during token exchanges or API calls, improving stability and responsiveness when authentication endpoints are slow or unresponsive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->