### PR TITLE
feat: extract real client IP from Funnel connections

### DIFF
--- a/internal/funnel/context.go
+++ b/internal/funnel/context.go
@@ -1,0 +1,54 @@
+// Package funnel provides utilities for extracting real client IPs from Tailscale Funnel connections.
+package funnel
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/netip"
+
+	"tailscale.com/ipn"
+)
+
+type contextKey struct{}
+
+// ConnContext returns a context enriched with the real client source address
+// when the connection is a Tailscale Funnel connection. This is intended to
+// be used as http.Server.ConnContext.
+func ConnContext(ctx context.Context, c net.Conn) context.Context {
+	if src, ok := extractFunnelSrc(c); ok {
+		return context.WithValue(ctx, contextKey{}, src)
+	}
+	return ctx
+}
+
+// SourceAddrFromContext returns the real client address from a Funnel
+// connection, if present in the context.
+func SourceAddrFromContext(ctx context.Context) (netip.AddrPort, bool) {
+	v, ok := ctx.Value(contextKey{}).(netip.AddrPort)
+	return v, ok
+}
+
+// WithSourceAddr returns a context with the given Funnel source address set.
+// This is useful for testing and for cases where the source address is known
+// outside of a ConnContext callback.
+func WithSourceAddr(ctx context.Context, src netip.AddrPort) context.Context {
+	return context.WithValue(ctx, contextKey{}, src)
+}
+
+// extractFunnelSrc unwraps TLS and checks for ipn.FunnelConn to get the
+// real source address of a Funnel client.
+func extractFunnelSrc(c net.Conn) (netip.AddrPort, bool) {
+	inner := c
+
+	// Unwrap *tls.Conn — ListenFunnel wraps connections in TLS.
+	if tc, ok := inner.(*tls.Conn); ok {
+		inner = tc.NetConn()
+	}
+
+	if fc, ok := inner.(*ipn.FunnelConn); ok {
+		return fc.Src, fc.Src.IsValid()
+	}
+
+	return netip.AddrPort{}, false
+}

--- a/internal/funnel/context_test.go
+++ b/internal/funnel/context_test.go
@@ -1,0 +1,55 @@
+// Package funnel provides utilities for extracting real client IPs from Tailscale Funnel connections.
+package funnel
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/ipn"
+)
+
+func TestConnContext_FunnelConn(t *testing.T) {
+	realClientIP := netip.MustParseAddrPort("203.0.113.42:52341")
+	funnelConn := &ipn.FunnelConn{
+		Conn: &mockConn{remoteAddr: &net.TCPAddr{IP: net.ParseIP("100.81.217.1"), Port: 12345}},
+		Src:  realClientIP,
+	}
+	tlsConn := tls.Client(funnelConn, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+
+	ctx := ConnContext(context.Background(), tlsConn)
+	got, ok := SourceAddrFromContext(ctx)
+
+	require.True(t, ok)
+	assert.Equal(t, realClientIP, got)
+}
+
+func TestConnContext_NonFunnelConn(t *testing.T) {
+	plainConn := &mockConn{remoteAddr: &net.TCPAddr{IP: net.ParseIP("100.64.1.1"), Port: 12345}}
+	tlsConn := tls.Client(plainConn, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+
+	ctx := ConnContext(context.Background(), tlsConn)
+	_, ok := SourceAddrFromContext(ctx)
+
+	assert.False(t, ok)
+}
+
+func TestConnContext_RawConn(t *testing.T) {
+	plainConn := &mockConn{remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 80}}
+
+	ctx := ConnContext(context.Background(), plainConn)
+	_, ok := SourceAddrFromContext(ctx)
+
+	assert.False(t, ok)
+}
+
+type mockConn struct {
+	net.Conn
+	remoteAddr net.Addr
+}
+
+func (c *mockConn) RemoteAddr() net.Addr { return c.remoteAddr }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/jtdowney/tsbridge/internal/constants"
 	"github.com/jtdowney/tsbridge/internal/errors"
+	"github.com/jtdowney/tsbridge/internal/funnel"
 	"github.com/jtdowney/tsbridge/internal/metrics"
 	"github.com/jtdowney/tsbridge/internal/middleware"
 )
@@ -214,6 +215,10 @@ func configureTrustedProxies(h *httpHandler, trustedProxies []string) error {
 // The Rewrite API strips X-Forwarded-For/Host/Proto before calling this function;
 // SetXForwarded() repopulates them. For trusted proxies, we copy the inbound XFF
 // first so SetXForwarded appends to the existing chain.
+//
+// For Funnel connections, the real client IP is stored in the request context
+// by the ConnContext callback. The Tailscale ingress node is implicitly trusted,
+// and the real client IP is injected into the X-Forwarded-For chain.
 func createProxyRewrite(h *httpHandler, target *url.URL) func(*httputil.ProxyRequest) {
 	return func(pr *httputil.ProxyRequest) {
 		pr.SetURL(target)
@@ -222,8 +227,14 @@ func createProxyRewrite(h *httpHandler, target *url.URL) func(*httputil.ProxyReq
 		clientIP, _, _ := net.SplitHostPort(pr.In.RemoteAddr)
 		fromTrustedProxy := h.isTrustedProxy(clientIP)
 
-		// For trusted proxies, copy inbound XFF so SetXForwarded appends to it
-		if fromTrustedProxy {
+		// For Funnel connections, the ingress node is implicitly trusted and
+		// the real client IP is injected as the start of the XFF chain.
+		funnelSrc, isFunnel := funnel.SourceAddrFromContext(pr.In.Context())
+		if isFunnel {
+			pr.Out.Header.Set("X-Forwarded-For", funnelSrc.Addr().String())
+			fromTrustedProxy = true
+		} else if fromTrustedProxy {
+			// For trusted proxies, copy inbound XFF so SetXForwarded appends to it
 			if xff := pr.In.Header["X-Forwarded-For"]; len(xff) > 0 {
 				pr.Out.Header["X-Forwarded-For"] = xff
 			}
@@ -232,7 +243,10 @@ func createProxyRewrite(h *httpHandler, target *url.URL) func(*httputil.ProxyReq
 		pr.SetXForwarded()
 
 		// Set X-Real-IP
-		if fromTrustedProxy {
+		switch {
+		case isFunnel:
+			pr.Out.Header.Set("X-Real-IP", funnelSrc.Addr().String())
+		case fromTrustedProxy:
 			if existingXFF := pr.In.Header.Get("X-Forwarded-For"); existingXFF != "" {
 				ips := strings.Split(existingXFF, ",")
 				if len(ips) > 0 {
@@ -241,7 +255,7 @@ func createProxyRewrite(h *httpHandler, target *url.URL) func(*httputil.ProxyReq
 			} else if clientIP != "" {
 				pr.Out.Header.Set("X-Real-IP", clientIP)
 			}
-		} else if clientIP != "" {
+		case clientIP != "":
 			pr.Out.Header.Set("X-Real-IP", clientIP)
 		}
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/jtdowney/tsbridge/internal/constants"
 	"github.com/jtdowney/tsbridge/internal/errors"
+	"github.com/jtdowney/tsbridge/internal/funnel"
 	"github.com/jtdowney/tsbridge/internal/metrics"
 )
 
@@ -601,6 +603,84 @@ func TestXForwardedForWithTrustedProxies(t *testing.T) {
 
 			actualRealIP := rr.Header().Get("X-Echo-Real-IP")
 			assert.Equal(t, tt.expectedRealIP, actualRealIP, "X-Real-IP mismatch")
+		})
+	}
+}
+
+func TestXForwardedForWithFunnelSourceIP(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Echo-Forwarded-For", r.Header.Get("X-Forwarded-For"))
+		w.Header().Set("X-Echo-Real-IP", r.Header.Get("X-Real-IP"))
+		fmt.Fprint(w, "OK")
+	}))
+	defer backend.Close()
+
+	tests := []struct {
+		name                 string
+		trustedProxies       []string
+		clientForwardedFor   string
+		remoteAddr           string
+		funnelSrcIP          string
+		funnelSrcPort        uint16
+		expectedForwardedFor string
+		expectedRealIP       string
+	}{
+		{
+			name:                 "funnel connection uses real client IP",
+			remoteAddr:           "100.81.217.1:12345",
+			funnelSrcIP:          "203.0.113.42",
+			funnelSrcPort:        52341,
+			expectedForwardedFor: "203.0.113.42, 100.81.217.1",
+			expectedRealIP:       "203.0.113.42",
+		},
+		{
+			name:                 "funnel connection with IPv6 source",
+			remoteAddr:           "[fd7a:115c:a1e0:ab12:4843:cd96:625a:9516]:12345",
+			funnelSrcIP:          "2001:db8::1",
+			funnelSrcPort:        8080,
+			expectedForwardedFor: "2001:db8::1, fd7a:115c:a1e0:ab12:4843:cd96:625a:9516",
+			expectedRealIP:       "2001:db8::1",
+		},
+		{
+			name:                 "funnel trusted regardless of trusted_proxies config",
+			trustedProxies:       nil,
+			remoteAddr:           "100.81.217.1:12345",
+			funnelSrcIP:          "198.51.100.1",
+			funnelSrcPort:        443,
+			expectedForwardedFor: "198.51.100.1, 100.81.217.1",
+			expectedRealIP:       "198.51.100.1",
+		},
+		{
+			name:                 "funnel connection ignores spoofed inbound X-Forwarded-For",
+			clientForwardedFor:   "8.8.8.8, 1.1.1.1",
+			remoteAddr:           "100.81.217.1:12345",
+			funnelSrcIP:          "203.0.113.42",
+			funnelSrcPort:        52341,
+			expectedForwardedFor: "203.0.113.42, 100.81.217.1",
+			expectedRealIP:       "203.0.113.42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := newTestHandler(backend.URL, defaultTestTransportConfig(), tt.trustedProxies)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest("GET", "/", nil)
+			if tt.clientForwardedFor != "" {
+				req.Header.Set("X-Forwarded-For", tt.clientForwardedFor)
+			}
+			req.RemoteAddr = tt.remoteAddr
+
+			funnelSrc := netip.AddrPortFrom(netip.MustParseAddr(tt.funnelSrcIP), tt.funnelSrcPort)
+			ctx := funnel.WithSourceAddr(req.Context(), funnelSrc)
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectedForwardedFor, rr.Header().Get("X-Echo-Forwarded-For"), "X-Forwarded-For mismatch")
+			assert.Equal(t, tt.expectedRealIP, rr.Header().Get("X-Echo-Real-IP"), "X-Real-IP mismatch")
 		})
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jtdowney/tsbridge/internal/config"
 	"github.com/jtdowney/tsbridge/internal/constants"
 	tserrors "github.com/jtdowney/tsbridge/internal/errors"
+	"github.com/jtdowney/tsbridge/internal/funnel"
 	"github.com/jtdowney/tsbridge/internal/metrics"
 	"github.com/jtdowney/tsbridge/internal/middleware"
 	"github.com/jtdowney/tsbridge/internal/proxy"
@@ -217,6 +218,11 @@ func (r *Registry) startService(svcCfg config.Service) (*Service, error) {
 	svc.server = &http.Server{
 		Handler:           svc.handler,
 		ReadHeaderTimeout: constants.DefaultReadHeaderTimeout, // Set default to satisfy linter
+	}
+
+	// For Funnel-enabled services, extract the real client IP from FunnelConn
+	if svcCfg.FunnelEnabled != nil && *svcCfg.FunnelEnabled {
+		svc.server.ConnContext = funnel.ConnContext
 	}
 
 	// Override with configured values if provided

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -2612,3 +2612,75 @@ func TestStartService_PartialFailure_CleansUpTsnetServers(t *testing.T) {
 	assert.True(t, exists, "good-service should exist in registry")
 	assert.NotNil(t, goodSvc, "good-service should not be nil")
 }
+
+func TestStartService_FunnelEnabled_SetsConnContext(t *testing.T) {
+	factory := func(serviceName string) tsnet.TSNetServer {
+		return tsnet.NewMockTSNetServer()
+	}
+
+	tsServerCfg := config.Tailscale{AuthKey: "test-key"}
+	tsServer, err := tailscale.NewServerWithFactory(tsServerCfg, factory)
+	require.NoError(t, err)
+	defer tsServer.Close()
+
+	funnelEnabled := true
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backendServer.Close()
+
+	cfg := &config.Config{
+		Services: []config.Service{
+			{
+				Name:          "funnel-svc",
+				BackendAddr:   backendServer.URL,
+				TLSMode:       "off",
+				FunnelEnabled: &funnelEnabled,
+			},
+		},
+	}
+
+	registry := NewRegistry(cfg, tsServer)
+	err = registry.StartServices()
+	require.NoError(t, err)
+	defer registry.Shutdown(context.Background())
+
+	svc, exists := registry.GetService("funnel-svc")
+	require.True(t, exists)
+	assert.NotNil(t, svc.server.ConnContext, "ConnContext should be set for Funnel-enabled service")
+}
+
+func TestStartService_FunnelDisabled_NoConnContext(t *testing.T) {
+	factory := func(serviceName string) tsnet.TSNetServer {
+		return tsnet.NewMockTSNetServer()
+	}
+
+	tsServerCfg := config.Tailscale{AuthKey: "test-key"}
+	tsServer, err := tailscale.NewServerWithFactory(tsServerCfg, factory)
+	require.NoError(t, err)
+	defer tsServer.Close()
+
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backendServer.Close()
+
+	cfg := &config.Config{
+		Services: []config.Service{
+			{
+				Name:        "plain-svc",
+				BackendAddr: backendServer.URL,
+				TLSMode:     "off",
+			},
+		},
+	}
+
+	registry := NewRegistry(cfg, tsServer)
+	err = registry.StartServices()
+	require.NoError(t, err)
+	defer registry.Shutdown(context.Background())
+
+	svc, exists := registry.GetService("plain-svc")
+	require.True(t, exists)
+	assert.Nil(t, svc.server.ConnContext, "ConnContext should not be set for non-Funnel service")
+}


### PR DESCRIPTION
Tailscale Funnel connections report the ingress node's IP as RemoteAddr, losing the real public client IP. The actual source is available in ipn.FunnelConn.Src but was never extracted.

Add internal/funnel package that detects FunnelConn via TLS unwrap in ConnContext, stores the real source address in request context, and uses it in the proxy to set X-Forwarded-For and X-Real-IP headers. The Funnel ingress node is implicitly trusted.

Closes #190