### PR TITLE
fix: clear TS_AUTHKEY env after config resolution

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -407,6 +407,9 @@ func resolveSecrets(cfg *Config) error {
 		}
 	}
 
+	os.Unsetenv("TS_AUTHKEY")
+	os.Unsetenv("TS_AUTH_KEY")
+
 	// Resolve State Directory (only if state_dir is not already set)
 	if cfg.Tailscale.StateDir == "" && cfg.Tailscale.StateDirEnv != "" {
 		resolved := os.Getenv(cfg.Tailscale.StateDirEnv)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -632,6 +632,51 @@ func TestResolveSecrets(t *testing.T) {
 	})
 }
 
+func TestResolveSecrets_clears_auth_key_env_vars(t *testing.T) {
+	t.Run("clears TS_AUTHKEY after resolving from env", func(t *testing.T) {
+		t.Setenv("TS_AUTHKEY", "test-key")
+		cfg := &Config{
+			Tailscale: Tailscale{},
+		}
+
+		err := resolveSecrets(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "test-key", cfg.Tailscale.AuthKey.Value())
+
+		_, exists := os.LookupEnv("TS_AUTHKEY")
+		assert.False(t, exists, "TS_AUTHKEY should be cleared after resolution")
+	})
+
+	t.Run("clears TS_AUTH_KEY after resolving", func(t *testing.T) {
+		t.Setenv("TS_AUTH_KEY", "test-key-2")
+		cfg := &Config{
+			Tailscale: Tailscale{},
+		}
+
+		err := resolveSecrets(cfg)
+		require.NoError(t, err)
+
+		_, exists := os.LookupEnv("TS_AUTH_KEY")
+		assert.False(t, exists, "TS_AUTH_KEY should be cleared after resolution")
+	})
+
+	t.Run("clears env vars even when auth key comes from config", func(t *testing.T) {
+		t.Setenv("TS_AUTHKEY", "env-key")
+		cfg := &Config{
+			Tailscale: Tailscale{
+				AuthKey: RedactedString("direct-key"),
+			},
+		}
+
+		err := resolveSecrets(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "direct-key", cfg.Tailscale.AuthKey.Value())
+
+		_, exists := os.LookupEnv("TS_AUTHKEY")
+		assert.False(t, exists, "TS_AUTHKEY should be cleared even when auth key came from config")
+	})
+}
+
 func TestServiceTLSModeValidationInConfig(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -38,15 +38,16 @@ const (
 
 // Provider implements config.Provider for Docker label-based configuration
 type Provider struct {
-	client        DockerClient
-	labelPrefix   string
-	socketPath    string
-	pollInterval  time.Duration
-	mu            sync.RWMutex
-	lastConfig    *config.Config
-	debounceTimer *time.Timer
-	debounceMu    sync.Mutex
-	pollTicker    *time.Ticker
+	client          DockerClient
+	labelPrefix     string
+	socketPath      string
+	pollInterval    time.Duration
+	mu              sync.RWMutex
+	lastConfig      *config.Config
+	cachedTailscale *config.Tailscale
+	debounceTimer   *time.Timer
+	debounceMu      sync.Mutex
+	pollTicker      *time.Ticker
 }
 
 // Options contains configuration options for the Docker provider
@@ -180,6 +181,15 @@ func (p *Provider) Load(ctx context.Context) (*config.Config, error) {
 		return nil, errors.WrapProviderError(err, "docker", errors.ErrTypeConfig, "parsing global configuration")
 	}
 
+	// Reuse cached Tailscale config on subsequent loads. The initial
+	// config resolution clears auth key env vars (TS_AUTHKEY) to prevent
+	// the tsnet library from independently reading them. Without this
+	// cache, subsequent Load() calls would fail to re-resolve the auth
+	// key from the now-cleared env vars.
+	if p.cachedTailscale != nil {
+		cfg.Tailscale = *p.cachedTailscale
+	}
+
 	// Find all containers with tsbridge.enabled=true
 	serviceContainers, err := p.findServiceContainers(ctx)
 	if err != nil {
@@ -208,6 +218,12 @@ func (p *Provider) Load(ctx context.Context) (*config.Config, error) {
 	// Docker provider allows zero services at startup
 	if err := config.ProcessLoadedConfigWithProvider(cfg, "docker"); err != nil {
 		return nil, err
+	}
+
+	// Cache the resolved Tailscale config after first successful load
+	if p.cachedTailscale == nil {
+		cached := cfg.Tailscale
+		p.cachedTailscale = &cached
 	}
 
 	slog.Info("Docker configuration loaded successfully",

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -95,7 +95,7 @@ func (s *Server) Listen(svc config.Service, tlsMode string, funnelEnabled bool) 
 	)
 
 	// Prepare auth key based on service type and existing state
-	if err := s.prepareServiceAuth(serviceServer, svc, baseStateDir); err != nil {
+	if _, err := s.prepareServiceAuth(serviceServer, svc, baseStateDir); err != nil {
 		return nil, err
 	}
 
@@ -153,7 +153,8 @@ func (s *Server) resolveBaseStateDir() (string, string) {
 }
 
 // prepareServiceAuth handles auth key generation/resolution based on service type and existing state.
-func (s *Server) prepareServiceAuth(serviceServer tsnetpkg.TSNetServer, svc config.Service, baseStateDir string) error {
+// Returns true if an auth key was set on the server, false if existing state is being used.
+func (s *Server) prepareServiceAuth(serviceServer tsnetpkg.TSNetServer, svc config.Service, baseStateDir string) (bool, error) {
 	var needsAuthKey bool
 	var authKeyReason string
 
@@ -177,21 +178,21 @@ func (s *Server) prepareServiceAuth(serviceServer tsnetpkg.TSNetServer, svc conf
 	if needsAuthKey {
 		// Now we actually need auth, so validate that we have OAuth or authkey
 		if err := ValidateTailscaleSecrets(s.config); err != nil {
-			return tserrors.WrapConfig(err, fmt.Sprintf("service %q needs authentication but %s", svc.Name, err.Error()))
+			return false, tserrors.WrapConfig(err, fmt.Sprintf("service %q needs authentication but %s", svc.Name, err.Error()))
 		}
 
 		slog.Debug("generating auth key", "service", svc.Name, "reason", authKeyReason)
 		cfg := config.Config{Tailscale: s.config}
 		authKey, err := generateOrResolveAuthKey(cfg, svc)
 		if err != nil {
-			return tserrors.WrapConfig(err, fmt.Sprintf("resolving auth key for service %q", svc.Name))
+			return false, tserrors.WrapConfig(err, fmt.Sprintf("resolving auth key for service %q", svc.Name))
 		}
 		serviceServer.SetAuthKey(authKey)
 		slog.Debug("auth key set for service", "service", svc.Name)
 	} else {
 		slog.Debug("using existing state, no auth key needed", "service", svc.Name)
 	}
-	return nil
+	return needsAuthKey, nil
 }
 
 // startServiceServer starts the tsnet server for a service.

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -577,7 +577,7 @@ func TestPrepareServiceAuth(t *testing.T) {
 			require.NoError(t, err)
 
 			// Test prepareServiceAuth
-			err = server.prepareServiceAuth(mockServer, tt.svc, tmpDir)
+			_, err = server.prepareServiceAuth(mockServer, tt.svc, tmpDir)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -589,6 +589,44 @@ func TestPrepareServiceAuth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrepareServiceAuth_returns_auth_key_status(t *testing.T) {
+	t.Run("returns true when auth key is set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mockServer := tsnet.NewMockTSNetServer()
+		factory := func(serviceName string) tsnet.TSNetServer { return mockServer }
+		server, err := NewServerWithFactory(config.Tailscale{
+			AuthKey: config.RedactedString("tskey-auth-123"),
+		}, factory)
+		require.NoError(t, err)
+
+		svc := config.Service{Name: "test-service"}
+		authKeySet, err := server.prepareServiceAuth(mockServer, svc, tmpDir)
+		require.NoError(t, err)
+		assert.True(t, authKeySet, "should return true when auth key was set")
+		assert.Equal(t, "tskey-auth-123", mockServer.AuthKey)
+	})
+
+	t.Run("returns false when existing state is used", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create existing state
+		serviceStateDir := filepath.Join(tmpDir, "test-service")
+		require.NoError(t, os.MkdirAll(serviceStateDir, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(serviceStateDir, "tailscaled.state"), []byte("mock state"), 0600))
+
+		mockServer := tsnet.NewMockTSNetServer()
+		factory := func(serviceName string) tsnet.TSNetServer { return mockServer }
+		server, err := NewServerWithFactory(config.Tailscale{}, factory)
+		require.NoError(t, err)
+
+		svc := config.Service{Name: "test-service"}
+		authKeySet, err := server.prepareServiceAuth(mockServer, svc, tmpDir)
+		require.NoError(t, err)
+		assert.False(t, authKeySet, "should return false when existing state is used")
+		assert.Empty(t, mockServer.AuthKey, "auth key should not be set on server")
+	})
 }
 
 func TestClose(t *testing.T) {


### PR DESCRIPTION
The tsnet library independently reads TS_AUTHKEY from the process environment via getAuthKey(), even when tsbridge has determined that existing state should be used. This can cause control servers (particularly Headscale) to register a new node on each restart instead of reusing the existing one.

Clear TS_AUTHKEY and TS_AUTH_KEY from the environment after resolving them into the config struct. Cache the resolved Tailscale config in the Docker provider so subsequent Load() calls don't fail from the cleared env vars.