### PR TITLE
feat(docker): add service discovery via tsbridge container labels

### DIFF
--- a/docs/docker-labels.md
+++ b/docs/docker-labels.md
@@ -135,6 +135,124 @@ labels:
   - "tsbridge.service.insecure_skip_verify=true" # Skip TLS cert verification (HTTPS backends only)
 ```
 
+### Service Definitions on Tsbridge Container
+
+You can also define services directly on the tsbridge container itself. This is useful when you want to pre-configure services that will be auto-discovered when their containers appear, without needing to add labels to each service container.
+
+This approach works well with dynamically created containers, such as those managed by [Nextcloud AIO](https://github.com/nextcloud/all-in-one) or other orchestrators that don't allow easy label configuration on service containers.
+
+#### Label Format
+
+Use labels in the format `tsbridge.service.{container_name}.{property}` on the tsbridge container:
+
+```yaml
+services:
+  tsbridge:
+    image: ghcr.io/jtdowney/tsbridge:latest
+    command: ["--provider", "docker"]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - tsbridge-state:/var/lib/tsbridge
+    environment:
+      - TS_OAUTH_CLIENT_ID=${TS_OAUTH_CLIENT_ID}
+      - TS_OAUTH_CLIENT_SECRET=${TS_OAUTH_CLIENT_SECRET}
+    labels:
+      # Required: OAuth setup
+      - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
+      - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
+      - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+      # Service definitions (NEW FEATURE)
+      - "tsbridge.service.nextcloud.port=80"
+      - "tsbridge.service.redis.port=6379"
+
+  # These containers are auto-discovered when they appear
+  # No tsbridge labels needed on the service containers themselves
+  nextcloud:
+    image: nextcloud:latest
+
+  redis:
+    image: redis:latest
+```
+
+#### How It Works
+
+1. tsbridge reads service definitions from its own container labels
+2. When a container with a matching name appears on the same network, it's automatically discovered
+3. The service inherits all standard configuration options (port, tags, timeouts, etc.)
+4. If the container stops, the proxy is removed
+
+#### Comparison with tsbridge.enabled=true
+
+| Approach | Use Case | Configuration Location |
+|----------|----------|----------------------|
+| `tsbridge.enabled=true` | Static compose files, full control | On each service container |
+| `tsbridge.service.{container_name}.*` | Dynamic containers, external orchestrators | On tsbridge container |
+
+#### Both Mechanisms Work Together
+
+You can use both approaches simultaneously. Services discovered via `tsbridge.enabled=true` take precedence if a service is found by both methods. This lets you gradually migrate or mix static and dynamic service discovery:
+
+```yaml
+services:
+  tsbridge:
+    image: ghcr.io/jtdowney/tsbridge:latest
+    command: ["--provider", "docker"]
+    labels:
+      - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
+      - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
+      # Pre-configure services that will appear dynamically
+      - "tsbridge.service.database.port=5432"
+
+  # Traditional approach - labels on service container
+  api:
+    image: myapi:latest
+    labels:
+      - "tsbridge.enabled=true"
+      - "tsbridge.service.port=8080"
+
+  # Auto-discovered via tsbridge container labels when it appears
+  database:
+    image: postgres:latest
+    # No tsbridge labels needed
+```
+
+#### Nextcloud AIO Example
+
+Nextcloud AIO creates containers dynamically, making it difficult to add labels to each service. With this feature, you can define all services on the tsbridge container:
+
+```yaml
+services:
+  tsbridge:
+    image: ghcr.io/jtdowney/tsbridge:latest
+    command: ["--provider", "docker"]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - tsbridge-state:/var/lib/tsbridge
+    environment:
+      - TS_OAUTH_CLIENT_ID=${TS_OAUTH_CLIENT_ID}
+      - TS_OAUTH_CLIENT_SECRET=${TS_OAUTH_CLIENT_SECRET}
+    networks:
+      - nextcloud-aio
+    labels:
+      - "tsbridge.tailscale.oauth_client_id_env=TS_OAUTH_CLIENT_ID"
+      - "tsbridge.tailscale.oauth_client_secret_env=TS_OAUTH_CLIENT_SECRET"
+      - "tsbridge.tailscale.state_dir=/var/lib/tsbridge"
+      # Define all Nextcloud AIO services
+      - "tsbridge.service.nextcloud-aio-apache.port=11000"
+      - "tsbridge.service.nextcloud-aio-collabora.port=9980"
+      - "tsbridge.service.nextcloud-aio-talk.port=3478"
+
+  # Nextcloud AIO master container creates these automatically
+  # They are discovered by name when they appear
+
+networks:
+  nextcloud-aio:
+    external: true
+```
+
+When Nextcloud AIO creates containers with names matching your definitions, tsbridge automatically exposes them on your Tailnet without any additional configuration.
+
+
 ## Backend Address Tips
 
 **Use port, not localhost:**

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -180,6 +180,17 @@ func (p *Provider) Load(ctx context.Context) (*config.Config, error) {
 	if err := p.parseGlobalConfig(selfContainer, cfg); err != nil {
 		return nil, errors.WrapProviderError(err, "docker", errors.ErrTypeConfig, "parsing global configuration")
 	}
+	// Parse service names from tsbridge container labels (new discovery mechanism)
+	labelServiceNames := p.parseServiceNames(selfContainer.Labels)
+	labelContainers := []container.Summary{}
+	if len(labelServiceNames) > 0 {
+		slog.Debug("discovering services from tsbridge container labels", "service_names", labelServiceNames)
+		labelContainers, err = p.findContainersByNames(ctx, labelServiceNames)
+		if err != nil {
+			return nil, errors.WrapProviderError(err, "docker", errors.ErrTypeResource, "finding containers by names")
+		}
+		slog.Debug("found containers from tsbridge labels", "count", len(labelContainers))
+	}
 
 	// Reuse cached Tailscale config on subsequent loads. The initial
 	// config resolution clears auth key env vars (TS_AUTHKEY) to prevent
@@ -195,9 +206,12 @@ func (p *Provider) Load(ctx context.Context) (*config.Config, error) {
 	if err != nil {
 		return nil, errors.WrapProviderError(err, "docker", errors.ErrTypeResource, "finding service containers")
 	}
-	slog.Debug("found service containers", "count", len(serviceContainers))
 
-	// Parse service configurations
+	// Parse service configurations and merge from both discovery mechanisms
+	// Use a map to deduplicate services by name - traditional discovery takes precedence
+	serviceMap := make(map[string]config.Service)
+
+	// First, process containers from traditional discovery (tsbridge.enabled=true)
 	for _, container := range serviceContainers {
 		containerName := ""
 		if len(container.Names) > 0 {
@@ -211,7 +225,36 @@ func (p *Provider) Load(ctx context.Context) (*config.Config, error) {
 				"error", err)
 			continue
 		}
-		cfg.Services = append(cfg.Services, *svc)
+		serviceMap[svc.Name] = *svc
+	}
+
+	// Then, process containers from new discovery (via tsbridge container labels)
+	// Only add if service name is not already present (traditional takes precedence)
+	for _, container := range labelContainers {
+		containerName := ""
+		if len(container.Names) > 0 {
+			containerName = container.Names[0]
+		}
+
+		svc, err := p.parseServiceConfig(container)
+		if err != nil {
+			slog.Warn("failed to parse service configuration",
+				"container", containerName,
+				"error", err)
+			continue
+		}
+
+		// Only add if not already present from traditional discovery
+		if _, exists := serviceMap[svc.Name]; !exists {
+			serviceMap[svc.Name] = *svc
+			slog.Info("Service discovered via tsbridge container labels", "service", svc.Name)
+		}
+	}
+
+	// Convert map to slice
+	cfg.Services = make([]config.Service, 0, len(serviceMap))
+	for _, svc := range serviceMap {
+		cfg.Services = append(cfg.Services, svc)
 	}
 
 	// Apply standard configuration processing
@@ -620,6 +663,55 @@ func (p *Provider) findServiceContainers(ctx context.Context) ([]container.Summa
 	}
 
 	return serviceContainers, nil
+}
+
+
+// findContainersByNames finds containers matching any of the given service names.
+// It queries all running containers and matches against their Names field.
+// Unlike findServiceContainers, this does NOT require tsbridge.enabled=true.
+// Container names in Docker are prefixed with '/', so they are stripped before matching.
+func (p *Provider) findContainersByNames(ctx context.Context, serviceNames []string) ([]container.Summary, error) {
+	// Return empty slice for nil or empty service names
+	if len(serviceNames) == 0 {
+		return []container.Summary{}, nil
+	}
+
+	// Query all running containers (no label filter)
+	opts := container.ListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("status", "running"),
+		),
+	}
+
+	containers, err := p.client.ContainerList(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a set of service names for O(1) lookup
+	serviceNameSet := make(map[string]struct{}, len(serviceNames))
+	for _, name := range serviceNames {
+		serviceNameSet[name] = struct{}{}
+	}
+
+	// Find containers whose names match any service name
+	var matching []container.Summary
+	for _, c := range containers {
+		for _, name := range c.Names {
+			// Strip leading '/' from container name
+			containerName := strings.TrimPrefix(name, "/")
+			if _, matches := serviceNameSet[containerName]; matches {
+				matching = append(matching, c)
+				break // Only add each container once
+			}
+		}
+	}
+
+	if matching == nil {
+		return []container.Summary{}, nil
+	}
+
+	return matching, nil
 }
 
 // getContainerByID gets a container by ID

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -2733,3 +2733,158 @@ func TestCloseStopsPollTicker(t *testing.T) {
 	// (calling Stop on an already stopped ticker is safe)
 	p.pollTicker.Stop()
 }
+
+func TestProvider_findContainersByNames(t *testing.T) {
+	provider := &Provider{labelPrefix: "tsbridge"}
+
+	tests := []struct {
+		name          string
+		serviceNames  []string
+		containers    []container.Summary
+		wantErr       bool
+		wantCount     int
+		wantNames     []string
+	}{
+		{
+			name:         "empty service names slice",
+			serviceNames: []string{},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/nextcloud"}},
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name:         "nil service names",
+			serviceNames: nil,
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/nextcloud"}},
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name:         "no matching containers",
+			serviceNames: []string{"nextcloud", "redis"},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/other"}},
+				{ID: "c2", Names: []string{"/nginx"}},
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name:         "single matching container",
+			serviceNames: []string{"nextcloud"},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/nextcloud"}},
+				{ID: "c2", Names: []string{"/other"}},
+			},
+			wantErr:   false,
+			wantCount: 1,
+			wantNames: []string{"/nextcloud"},
+		},
+		{
+			name:         "multiple matching containers",
+			serviceNames: []string{"nextcloud", "redis"},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/nextcloud"}},
+				{ID: "c2", Names: []string{"/redis"}},
+				{ID: "c3", Names: []string{"/nginx"}},
+			},
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name:         "container name with leading slash",
+			serviceNames: []string{"nextcloud"},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/nextcloud"}}, // Has leading slash
+			},
+			wantErr:   false,
+			wantCount: 1,
+			wantNames: []string{"/nextcloud"},
+		},
+		{
+			name:         "container without leading slash in input",
+			serviceNames: []string{"nextcloud"},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"nextcloud"}}, // No leading slash (edge case)
+			},
+			wantErr:   false,
+			wantCount: 1,
+			wantNames: []string{"nextcloud"},
+		},
+		{
+			name:         "container with multiple names - first matches",
+			serviceNames: []string{"nextcloud"},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/nextcloud", "/nc-alias"}},
+			},
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name:         "no containers at all",
+			serviceNames: []string{"nextcloud"},
+			containers:  []container.Summary{},
+			wantErr:     false,
+			wantCount:   0,
+		},
+		{
+			name:         "service name not in list returns empty",
+			serviceNames: []string{"mysql", "postgres"},
+			containers: []container.Summary{
+				{ID: "c1", Names: []string{"/redis"}},
+				{ID: "c2", Names: []string{"/mongo"}},
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := newMockDockerClient()
+			mockClient.containers = tt.containers
+
+			provider.client = mockClient
+
+			ctx := context.Background()
+			result, err := provider.findContainersByNames(ctx, tt.serviceNames)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, result, tt.wantCount)
+
+			if tt.wantNames != nil && len(result) > 0 {
+				var resultNames []string
+				for _, c := range result {
+					resultNames = append(resultNames, c.Names...)
+				}
+				assert.Equal(t, tt.wantNames, resultNames)
+			}
+		})
+	}
+}
+
+func TestProvider_findContainersByNames_Error(t *testing.T) {
+	mockClient := newMockDockerClient()
+	mockClient.listError = fmt.Errorf("docker API error")
+
+	provider := &Provider{
+		client:      mockClient,
+		labelPrefix: "tsbridge",
+	}
+
+	ctx := context.Background()
+	_, err := provider.findContainersByNames(ctx, []string{"nextcloud"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker API error")
+}
+

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -353,3 +353,45 @@ func parseByteSize(value string) (int64, error) {
 	}
 	return config.ParseByteSizeString(value)
 }
+
+// parseServiceNames parses service names from container labels.
+// It looks for labels matching pattern {prefix}.service.{container_name}.{property}
+// and extracts unique service names.
+// Returns a slice of unique service names found in the labels.
+func (p *Provider) parseServiceNames(labels map[string]string) []string {
+	// Build the prefix pattern: {prefix}.service.
+	prefix := fmt.Sprintf("%s.service.", p.labelPrefix)
+
+	// Use a map to track unique service names
+	serviceNames := make(map[string]struct{})
+
+	// Iterate through all labels
+	for labelKey := range labels {
+		// Check if the label starts with {prefix}.service.
+		if strings.HasPrefix(labelKey, prefix) {
+			// Extract the remaining part after {prefix}.service.
+			rest := strings.TrimPrefix(labelKey, prefix)
+
+			// Find the service name (part before the next dot)
+			// Labels are: {prefix}.service.{container_name}.{property}
+			if idx := strings.Index(rest, "."); idx > 0 {
+				serviceName := rest[:idx]
+				if serviceName != "" {
+					serviceNames[serviceName] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(serviceNames) == 0 {
+		return nil
+	}
+
+	// Convert map to slice
+	result := make([]string, 0, len(serviceNames))
+	for name := range serviceNames {
+		result = append(result, name)
+	}
+
+	return result
+}

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -973,6 +974,123 @@ func TestDockerServiceOAuthPreauthorizedParsing(t *testing.T) {
 				require.NotNil(t, svc.OAuthPreauthorized)
 				assert.Equal(t, *tt.expected, *svc.OAuthPreauthorized)
 			}
+		})
+	}
+}
+func TestParseServiceNames(t *testing.T) {
+	provider := &Provider{
+		labelPrefix: "tsbridge",
+	}
+
+	tests := []struct {
+		name          string
+		labels        map[string]string
+		expectedNames []string
+	}{
+		{
+			name:          "empty labels map",
+			labels:        map[string]string{},
+			expectedNames: nil,
+		},
+		{
+			name: "no matching service labels",
+			labels: map[string]string{
+				"tsbridge.enabled":             "true",
+				"tsbridge.tailscale.state_dir": "/var/lib/tsbridge",
+			},
+			expectedNames: nil,
+		},
+		{
+			name: "single service with one property",
+			labels: map[string]string{
+				"tsbridge.enabled":                "true",
+				"tsbridge.service.nextcloud.port": "80",
+			},
+			expectedNames: []string{"nextcloud"},
+		},
+		{
+			name: "single service with multiple properties",
+			labels: map[string]string{
+				"tsbridge.enabled":                "true",
+				"tsbridge.service.nextcloud.port": "80",
+				"tsbridge.service.nextcloud.tags": "tag:prod",
+			},
+			expectedNames: []string{"nextcloud"},
+		},
+		{
+			name: "multiple services",
+			labels: map[string]string{
+				"tsbridge.enabled":                "true",
+				"tsbridge.service.nextcloud.port": "80",
+				"tsbridge.service.redis.port":     "6379",
+			},
+			expectedNames: []string{"nextcloud", "redis"},
+		},
+		{
+			name: "multiple services with multiple properties",
+			labels: map[string]string{
+				"tsbridge.enabled":                "true",
+				"tsbridge.service.nextcloud.port": "80",
+				"tsbridge.service.nextcloud.tags": "tag:prod",
+				"tsbridge.service.redis.port":     "6379",
+				"tsbridge.service.redis.tags":     "tag:cache",
+			},
+			expectedNames: []string{"nextcloud", "redis"},
+		},
+		{
+			name: "duplicate service names should deduplicate",
+			labels: map[string]string{
+				"tsbridge.enabled":                "true",
+				"tsbridge.service.nextcloud.port": "80",
+				"tsbridge.service.nextcloud.tags": "tag:prod",
+			},
+			expectedNames: []string{"nextcloud"},
+		},
+		{
+			name: "custom label prefix - using tsbridge prefix",
+			labels: map[string]string{
+				"tsbridge.enabled":            "true",
+				"tsbridge.service.myapp.port": "3000",
+			},
+			expectedNames: []string{"myapp"},
+		},
+
+		{
+			name: "service name with hyphen",
+			labels: map[string]string{
+				"tsbridge.enabled":                 "true",
+				"tsbridge.service.my-web-app.port": "8080",
+			},
+			expectedNames: []string{"my-web-app"},
+		},
+		{
+			name: "service name with underscore",
+			labels: map[string]string{
+				"tsbridge.enabled":                 "true",
+				"tsbridge.service.my_web_app.port": "8080",
+			},
+			expectedNames: []string{"my_web_app"},
+		},
+		{
+			name: "ignores non-service labels with similar prefix",
+			labels: map[string]string{
+				"tsbridge.enabled":          "true",
+				"tsbridge.servicefoo.port":  "80",
+				"tsbridge.service.bar.port": "8080",
+			},
+			expectedNames: []string{"bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.parseServiceNames(tt.labels)
+
+			// Convert to sorted slice for comparison to ensure deterministic results
+			sort.Strings(result)
+			sort.Strings(tt.expectedNames)
+
+			assert.Equal(t, tt.expectedNames, result)
 		})
 	}
 }


### PR DESCRIPTION
Add ability to define services on the tsbridge container itself, enabling auto-discovery of matching containers even without tsbridge.enabled=true.

This is useful for dynamically created containers (like Nextcloud AIO) where adding labels to service containers isn't possible.

Changes:
- Add parseServiceNames() to extract service names from tsbridge container labels
- Add findContainersByNames() to discover containers by name
- Modify Load() to merge services from both discovery mechanisms
- Traditional discovery (tsbridge.enabled=true) takes precedence
- Add comprehensive unit tests
- Update documentation with examples and use cases

Closes: docker-service-discovery